### PR TITLE
chore: ignore JetBrains .idea folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ coverage
 .eslintcache
 *.log*
 *.env*
+.idea


### PR DESCRIPTION
This ensures that the `.idea` folder from JetBrains IDEs is ignored by git.