### PR TITLE
feat: add scope tracker

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -10,30 +10,111 @@ import { parseSync } from 'oxc-parser'
 /** estree also has AssignmentProperty, Identifier and Literal as possible node types */
 export type Node = Declaration | Expression | ClassBody | CatchClause | MethodDefinition | ModuleDeclaration | ImportSpecifier | ImportDefaultSpecifier | ImportNamespaceSpecifier | ExportSpecifier | Pattern | PrivateIdentifier | Program | SpreadElement | Statement | Super | SwitchCase | TemplateElement | ObjectProperty | PropertyDefinition
 
-type WalkerCallback = (this: ThisParameterType<SyncHandler>, node: Node, parent: Node | null, ctx: { key: string | number | symbol | null | undefined, index: number | null | undefined, ast: Program | Node, magicString?: MagicString | undefined }) => void
-
-interface WalkOptions {
-  enter: WalkerCallback
-  leave: WalkerCallback
+interface WalkerCallbackContext<TInput extends Program | Node | ParseResult, TOptions extends Partial<_WalkOptions<TInput>>> {
+  /**
+   * The key of the current node within its parent node object, if applicable.
+   *
+   * For instance, when processing a `VariableDeclarator` node, this would be the `declarations` key of the parent `VariableDeclaration` node.
+   * @example
+   * {
+   *   type: 'VariableDeclaration',
+   *   declarations: [[Object]],
+   *   // ...
+   * },
+   *   {  // <-- when processing this, the key would be 'declarations'
+   *     type: 'VariableDeclarator',
+   *     // ...
+   *   },
+   */
+  key: string | number | symbol | null | undefined
+  /**
+   * The zero-based index of the current node within its parent's children array, if applicable.
+   * For instance, when processing a `VariableDeclarator` node,
+   * this would be the index of the current `VariableDeclarator` node within the `declarations` array.
+   *
+   * This is `null` when the node is not part of an array and `undefined` for the root `Program` node.
+   *
+   * @example
+   * {
+   *   type: 'VariableDeclaration',
+   *   declarations: [[Object]],
+   *   // ...
+   * },
+   *   {  // <-- when processing this, the index would be 0
+   *     type: 'VariableDeclarator',
+   *     // ...
+   *   },
+   */
+  index: number | null | undefined
+  /**
+   * The full Abstract Syntax Tree (AST) that is being walked, starting from the root node.
+   */
+  ast: Program | Node
+  /**
+   * The MagicString instance that is being used to modify the code.
+   */
+  magicString: TInput extends ParseResult ? MagicString : TOptions['magicString'] extends MagicString ? MagicString : undefined
 }
 
-export function walk(input: Program | Node | ParseResult, options: Partial<WalkOptions>) {
-  const [ast, magicString] = 'magicString' in input ? [input.program, input.magicString] : [input]
-  return _walk(ast as unknown as ESTreeProgram | ESTreeNode, {
-    enter(node, parent, key, index) {
-      options.enter?.call(this, node as Node, parent as Node | null, { key, index, ast, magicString })
+type WalkerCallback<TInput extends Program | Node | ParseResult, TOptions extends Partial<_WalkOptions<TInput>>> = (this: ThisParameterType<SyncHandler>, node: Node, parent: Node | null, ctx: WalkerCallbackContext<TInput, TOptions>) => void
+
+interface _WalkOptions<TInput extends Program | Node | ParseResult> {
+  /**
+   * The oxc MagicString instance to be used to modify the code.
+   *
+   * When the input is a `ParseResult`, the MagicString from the result is used.
+   */
+  magicString: TInput extends ParseResult ? never : MagicString | undefined
+}
+
+type WalkOptions<TInput extends Program | Node | ParseResult, TOptions extends Partial<_WalkOptions<TInput>>> = {
+  /**
+   * The function to be called when entering a node.
+   */
+  enter: WalkerCallback<TInput, TOptions>
+  /**
+   * The function to be called when leaving a node.
+   */
+  leave: WalkerCallback<TInput, TOptions>
+} & TOptions
+
+/**
+ * Walk the AST with the given options.
+ * @param input The AST to walk.
+ * @param options The options to be used when walking the AST. Here you can specify the callbacks for entering and leaving nodes, as well as other options.
+ */
+export function walk<T extends Program | Node | ParseResult, TOptions extends _WalkOptions<T>>(input: T, options: Partial<WalkOptions<T, TOptions>>) {
+  const [ast, magicString] = 'magicString' in input ? [input.program, input.magicString] : [input, options.magicString]
+  return _walk(
+    ast as unknown as ESTreeProgram | ESTreeNode,
+    {
+      enter(node, parent, key, index) {
+        options.enter?.call(this, node as Node, parent as Node | null, { key, index, ast, magicString } as WalkerCallbackContext<T, TOptions>)
+      },
+      leave(node, parent, key, index) {
+        options.leave?.call(this, node as Node, parent as Node | null, { key, index, ast, magicString } as WalkerCallbackContext<T, TOptions>)
+      },
     },
-    leave(node, parent, key, index) {
-      options.leave?.call(this, node as Node, parent as Node | null, { key, index, ast, magicString })
-    },
-  }) as Program | Node | null
+  ) as Program | Node | null
 }
 
 const LANG_RE = createRegExp(exactly('jsx').or('tsx').or('js').or('ts').groupedAs('lang').after(exactly('.').and(anyOf('c', 'm').optionally())))
 
-export function parseAndWalk(code: string, sourceFilename: string, callback: WalkerCallback): ParseResult
-export function parseAndWalk(code: string, sourceFilename: string, options: Partial<WalkOptions>): ParseResult
-export function parseAndWalk(code: string, sourceFilename: string, arg3: Partial<WalkOptions> | WalkerCallback) {
+/**
+ * Parse the code and walk the AST with the given callback, which is called when entering a node.
+ * @param code The string with the code to parse and walk. This can be javascript, typescript, jsx or tsx.
+ * @param sourceFilename The filename of the source code. This is used to determine the language of the code.
+ * @param callback The callback to be called when entering a node.
+ */
+export function parseAndWalk(code: string, sourceFilename: string, callback: WalkerCallback<ParseResult, object>): ParseResult
+/**
+ * Parse the code and walk the AST with the given callback(s).
+ * @param code The string with the code to parse and walk. This can be javascript, typescript, jsx or tsx.
+ * @param sourceFilename The filename of the source code. This is used to determine the language of the code.
+ * @param options The options to be used when walking the AST. Here you can specify the callbacks for entering and leaving nodes, as well as other options.
+ */
+export function parseAndWalk(code: string, sourceFilename: string, options: Partial<WalkOptions<ParseResult, object>>): ParseResult
+export function parseAndWalk(code: string, sourceFilename: string, arg3: Partial<WalkOptions<ParseResult, object>> | WalkerCallback<ParseResult, object>) {
   const lang = sourceFilename?.match(LANG_RE)?.groups?.lang
   const result = parseSync(sourceFilename, code, { sourceType: 'module', lang })
   walk(result, typeof arg3 === 'function' ? { enter: arg3 } : arg3)

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,14 +1,17 @@
 import type { Node as ESTreeNode, Program as ESTreeProgram } from 'estree'
 import type { SyncHandler } from 'estree-walker'
 
-import type { CatchClause, ClassBody, Declaration, ExportSpecifier, Expression, ImportDefaultSpecifier, ImportNamespaceSpecifier, ImportSpecifier, MagicString, MethodDefinition, ModuleDeclaration, ObjectProperty, ParseResult, Pattern, PrivateIdentifier, Program, PropertyDefinition, SpreadElement, Statement, Super, SwitchCase, TemplateElement } from 'oxc-parser'
+import type { ArrayPattern, AssignmentPattern, AssignmentTargetMaybeDefault, AssignmentTargetRest, BindingIdentifier, BindingPattern, CatchClause, ClassBody, ClassElement, Declaration, ExportSpecifier, Expression, IdentifierName, IdentifierReference, ImportDefaultSpecifier, ImportNamespaceSpecifier, ImportSpecifier, LabelIdentifier, MagicString, MethodDefinition, ModuleDeclaration, ObjectPattern, ObjectProperty, ParamPattern, ParseResult, Pattern, PrivateIdentifier, Program, PropertyDefinition, SpreadElement, Statement, Super, SwitchCase, TemplateElement, TSIndexSignatureName, VariableDeclarator, WithClause } from 'oxc-parser'
 
 import { walk as _walk } from 'estree-walker'
 import { anyOf, createRegExp, exactly } from 'magic-regexp/further-magic'
 import { parseSync } from 'oxc-parser'
+import { ScopeTracker } from './scope-tracker'
+
+export type Identifier = IdentifierName | IdentifierReference | BindingIdentifier | LabelIdentifier | TSIndexSignatureName
 
 /** estree also has AssignmentProperty, Identifier and Literal as possible node types */
-export type Node = Declaration | Expression | ClassBody | CatchClause | MethodDefinition | ModuleDeclaration | ImportSpecifier | ImportDefaultSpecifier | ImportNamespaceSpecifier | ExportSpecifier | Pattern | PrivateIdentifier | Program | SpreadElement | Statement | Super | SwitchCase | TemplateElement | ObjectProperty | PropertyDefinition
+export type Node = AssignmentTargetMaybeDefault | AssignmentTargetRest | Declaration | VariableDeclarator | Expression | Identifier | ClassBody | ClassElement | CatchClause | WithClause | MethodDefinition | ModuleDeclaration | ImportSpecifier | ImportDefaultSpecifier | ImportNamespaceSpecifier | ExportSpecifier | Pattern | PrivateIdentifier | Program | SpreadElement | Statement | Super | SwitchCase | TemplateElement | ObjectProperty | PropertyDefinition | BindingPattern | ParamPattern | ObjectPattern | ArrayPattern | AssignmentPattern
 
 interface WalkerCallbackContext<TInput extends Program | Node | ParseResult, TOptions extends Partial<_WalkOptions<TInput>>> {
   /**
@@ -58,6 +61,14 @@ interface WalkerCallbackContext<TInput extends Program | Node | ParseResult, TOp
 
 type WalkerCallback<TInput extends Program | Node | ParseResult, TOptions extends Partial<_WalkOptions<TInput>>> = (this: ThisParameterType<SyncHandler>, node: Node, parent: Node | null, ctx: WalkerCallbackContext<TInput, TOptions>) => void
 
+interface WalkScopeTrackingOptions {
+  /**
+   * Whether to do a pre-pass to collect all identifiers in advance.
+   * @default false
+   */
+  collect?: boolean
+}
+
 interface _WalkOptions<TInput extends Program | Node | ParseResult> {
   /**
    * The oxc MagicString instance to be used to modify the code.
@@ -65,6 +76,17 @@ interface _WalkOptions<TInput extends Program | Node | ParseResult> {
    * When the input is a `ParseResult`, the MagicString from the result is used.
    */
   magicString: TInput extends ParseResult ? never : MagicString | undefined
+  /**
+   * Options for managing scope tracking. By default, no scope tracking is performed.
+   *
+   * You can either provide a scope tracker class to use, set this option to `true`, or
+   * provide an object with options to enable scope tracking.
+   *
+   * When set to `true`, no identifier collection will be done beforehand. This means that
+   * hoisted identifiers will not be handled properly.
+   * @default undefined
+   */
+  scope: ScopeTracker | true | WalkScopeTrackingOptions
 }
 
 type WalkOptions<TInput extends Program | Node | ParseResult, TOptions extends Partial<_WalkOptions<TInput>>> = {
@@ -85,17 +107,53 @@ type WalkOptions<TInput extends Program | Node | ParseResult, TOptions extends P
  */
 export function walk<T extends Program | Node | ParseResult, TOptions extends _WalkOptions<T>>(input: T, options: Partial<WalkOptions<T, TOptions>>) {
   const [ast, magicString] = 'magicString' in input ? [input.program, input.magicString] : [input, options.magicString]
-  return _walk(
-    ast as unknown as ESTreeProgram | ESTreeNode,
-    {
-      enter(node, parent, key, index) {
-        options.enter?.call(this, node as Node, parent as Node | null, { key, index, ast, magicString } as WalkerCallbackContext<T, TOptions>)
+
+  const scopeTrackingOptions: WalkScopeTrackingOptions = options.scope instanceof ScopeTracker || typeof options.scope !== 'object' ? {} : options.scope
+  const scopeTracker = options.scope instanceof ScopeTracker
+    ? options.scope
+    : options.scope !== undefined
+      ? new ScopeTracker({
+        keepExitedScopes: scopeTrackingOptions.collect,
+      })
+      : null
+
+  if (scopeTrackingOptions.collect && scopeTracker) {
+    _walk(ast as unknown as ESTreeProgram | ESTreeNode, {
+      enter(node) {
+        // @ts-expect-error - accessing a protected property
+        scopeTracker.processNodeEnter(node)
       },
-      leave(node, parent, key, index) {
-        options.leave?.call(this, node as Node, parent as Node | null, { key, index, ast, magicString } as WalkerCallbackContext<T, TOptions>)
+      leave(node) {
+        // @ts-expect-error - accessing a protected property
+        scopeTracker.processNodeLeave(node)
       },
-    },
-  ) as Program | Node | null
+    })
+
+    scopeTracker.freeze()
+  }
+
+  return {
+    ast: _walk(
+      ast as unknown as ESTreeProgram | ESTreeNode,
+      {
+        enter(node, parent, key, index) {
+          if (!scopeTrackingOptions.collect) {
+            // @ts-expect-error - accessing a protected property; estree also has AssignmentProperty type, which is not in Node
+            scopeTracker?.processNodeEnter(node)
+          }
+          options.enter?.call(this, node as Node, parent as Node | null, { key, index, ast, magicString } as WalkerCallbackContext<T, TOptions>)
+        },
+        leave(node, parent, key, index) {
+          if (!scopeTrackingOptions.collect) {
+            // @ts-expect-error - accessing a protected property; estree also has AssignmentProperty type, which is not in Node
+            scopeTracker?.processNodeLeave(node)
+          }
+          options.leave?.call(this, node as Node, parent as Node | null, { key, index, ast, magicString } as WalkerCallbackContext<T, TOptions>)
+        },
+      },
+    ) as Program | Node | null,
+    scopeTracker: scopeTracker as TOptions['scope'] extends undefined ? null : ScopeTracker,
+  }
 }
 
 const LANG_RE = createRegExp(exactly('jsx').or('tsx').or('js').or('ts').groupedAs('lang').after(exactly('.').and(anyOf('c', 'm').optionally())))
@@ -106,17 +164,17 @@ const LANG_RE = createRegExp(exactly('jsx').or('tsx').or('js').or('ts').groupedA
  * @param sourceFilename The filename of the source code. This is used to determine the language of the code.
  * @param callback The callback to be called when entering a node.
  */
-export function parseAndWalk(code: string, sourceFilename: string, callback: WalkerCallback<ParseResult, object>): ParseResult
+export function parseAndWalk<TOptions extends Partial<_WalkOptions<ParseResult>>>(code: string, sourceFilename: string, callback: WalkerCallback<ParseResult, TOptions>): ParseResult
 /**
  * Parse the code and walk the AST with the given callback(s).
  * @param code The string with the code to parse and walk. This can be javascript, typescript, jsx or tsx.
  * @param sourceFilename The filename of the source code. This is used to determine the language of the code.
  * @param options The options to be used when walking the AST. Here you can specify the callbacks for entering and leaving nodes, as well as other options.
  */
-export function parseAndWalk(code: string, sourceFilename: string, options: Partial<WalkOptions<ParseResult, object>>): ParseResult
-export function parseAndWalk(code: string, sourceFilename: string, arg3: Partial<WalkOptions<ParseResult, object>> | WalkerCallback<ParseResult, object>) {
+export function parseAndWalk<TOptions extends Partial<_WalkOptions<ParseResult>>>(code: string, sourceFilename: string, options: Partial<WalkOptions<ParseResult, TOptions>>): ParseResult
+export function parseAndWalk<TOptions extends Partial<_WalkOptions<ParseResult>>>(code: string, sourceFilename: string, arg3: Partial<WalkOptions<ParseResult, TOptions>> | WalkerCallback<ParseResult, TOptions>) {
   const lang = sourceFilename?.match(LANG_RE)?.groups?.lang
   const result = parseSync(sourceFilename, code, { sourceType: 'module', lang })
-  walk(result, typeof arg3 === 'function' ? { enter: arg3 } : arg3)
+  walk(result, (typeof arg3 === 'function' ? { enter: arg3 } : arg3) as any) // TODO: use a more specific type cast
   return result
 }

--- a/src/scope-tracker.ts
+++ b/src/scope-tracker.ts
@@ -1,0 +1,574 @@
+import type {
+  ArrowFunctionExpression,
+  CatchClause,
+  Function,
+  IdentifierReference,
+  ImportDeclarationSpecifier,
+  VariableDeclaration,
+} from 'oxc-parser'
+import type { Identifier, Node } from './index'
+import { walk } from './index'
+/**
+ * A class to track variable scopes and declarations of identifiers within a JavaScript AST.
+ * It maintains a stack of scopes, where each scope is a map of identifier names to their corresponding
+ * declaration nodes - allowing to get to the declaration easily.
+ *
+ * The class has integration with the `walk` function to automatically track scopes and declarations
+ * and that's why only the informative methods are exposed.
+ *
+ * ### Scope tracking
+ * Scopes are created when entering a block statement, however, they are also created
+ * for function parameters, loop variable declarations, etc. (e.g. `i` in `for (let i = 0; i < 10; i++) { ... }`).
+ * This means that the behaviour is not 100% equivalent to JavaScript's scoping rules, because internally,
+ * one JavaScript scope can be spread across multiple scopes in this class.
+ *
+ * @example
+ * ```ts
+ * const scopeTracker = new ScopeTracker()
+ * walk(code, {
+ *   scope: scopeTracker,
+ *   enter(node) {
+ *     // ...
+ *   },
+ * })
+ * ```
+ *
+ * @see parseAndWalk
+ * @see walk
+ */
+export class ScopeTracker {
+  protected scopeIndexStack: number[] = []
+  protected scopeIndexKey = ''
+  protected scopes: Map<string, Map<string, ScopeTrackerNode>> = new Map()
+
+  protected options: Partial<ScopeTrackerOptions>
+  protected isFrozen = false
+
+  constructor(options: ScopeTrackerOptions = {}) {
+    this.options = options
+  }
+
+  protected updateScopeIndexKey() {
+    this.scopeIndexKey = this.scopeIndexStack.slice(0, -1).join('-')
+  }
+
+  protected pushScope() {
+    this.scopeIndexStack.push(0)
+    this.updateScopeIndexKey()
+  }
+
+  protected popScope() {
+    this.scopeIndexStack.pop()
+    if (this.scopeIndexStack[this.scopeIndexStack.length - 1] !== undefined) {
+      this.scopeIndexStack[this.scopeIndexStack.length - 1]!++
+    }
+
+    if (!this.options.keepExitedScopes) {
+      this.scopes.delete(this.scopeIndexKey)
+    }
+
+    this.updateScopeIndexKey()
+  }
+
+  protected declareIdentifier(name: string, data: ScopeTrackerNode) {
+    if (this.isFrozen) {
+      return
+    }
+
+    let scope = this.scopes.get(this.scopeIndexKey)
+    if (!scope) {
+      scope = new Map()
+      this.scopes.set(this.scopeIndexKey, scope)
+    }
+    scope.set(name, data)
+  }
+
+  protected declareFunctionParameter(param: Node, fn: Function | ArrowFunctionExpression) {
+    if (this.isFrozen) {
+      return
+    }
+
+    const identifiers = getPatternIdentifiers(param)
+    for (const identifier of identifiers) {
+      this.declareIdentifier(identifier.name, new ScopeTrackerFunctionParam(identifier, this.scopeIndexKey, fn))
+    }
+  }
+
+  protected declarePattern(pattern: Node, parent: VariableDeclaration | ArrowFunctionExpression | CatchClause | Function) {
+    if (this.isFrozen) {
+      return
+    }
+
+    const identifiers = getPatternIdentifiers(pattern)
+    for (const identifier of identifiers) {
+      this.declareIdentifier(
+        identifier.name,
+        parent.type === 'VariableDeclaration'
+          ? new ScopeTrackerVariable(identifier, this.scopeIndexKey, parent)
+          : parent.type === 'CatchClause'
+            ? new ScopeTrackerCatchParam(identifier, this.scopeIndexKey, parent)
+            : new ScopeTrackerFunctionParam(identifier, this.scopeIndexKey, parent),
+      )
+    }
+  }
+
+  protected processNodeEnter(node: Node) {
+    switch (node.type) {
+      case 'Program':
+      case 'BlockStatement':
+      case 'StaticBlock':
+        this.pushScope()
+        break
+
+      case 'FunctionDeclaration':
+        // declare function name for named functions, skip for `export default`
+        if (node.id?.name) {
+          this.declareIdentifier(node.id.name, new ScopeTrackerFunction(node, this.scopeIndexKey))
+        }
+        this.pushScope()
+        for (const param of node.params) {
+          this.declareFunctionParameter(param, node)
+        }
+        break
+
+      case 'FunctionExpression':
+        // make the name of the function available only within the function
+        // e.g. const foo = function bar() {  // bar is only available within the function body
+        this.pushScope()
+        // can be undefined, for example in class method definitions
+        if (node.id?.name) {
+          this.declareIdentifier(node.id.name, new ScopeTrackerFunction(node, this.scopeIndexKey))
+        }
+
+        this.pushScope()
+        for (const param of node.params) {
+          this.declareFunctionParameter(param, node)
+        }
+        break
+      case 'ArrowFunctionExpression':
+        this.pushScope()
+        for (const param of node.params) {
+          this.declareFunctionParameter(param, node)
+        }
+        break
+
+      case 'VariableDeclaration':
+        for (const decl of node.declarations) {
+          this.declarePattern(decl.id, node)
+        }
+        break
+
+      case 'ClassDeclaration':
+        // declare class name for named classes, skip for `export default`
+        if (node.id?.name) {
+          this.declareIdentifier(node.id.name, new ScopeTrackerIdentifier(node.id, this.scopeIndexKey))
+        }
+        break
+
+      case 'ClassExpression':
+        // make the name of the class available only within the class
+        // e.g. const MyClass = class InternalClassName { // InternalClassName is only available within the class body
+        this.pushScope()
+        if (node.id?.name) {
+          this.declareIdentifier(node.id.name, new ScopeTrackerIdentifier(node.id, this.scopeIndexKey))
+        }
+        break
+
+      case 'ImportDeclaration':
+        for (const specifier of node.specifiers) {
+          this.declareIdentifier(specifier.local.name, new ScopeTrackerImport(specifier, this.scopeIndexKey, node))
+        }
+        break
+
+      case 'CatchClause':
+        this.pushScope()
+        if (node.param) {
+          this.declarePattern(node.param, node)
+        }
+        break
+
+      case 'ForStatement':
+      case 'ForOfStatement':
+      case 'ForInStatement':
+        // make the variables defined in for loops available only within the loop
+        // e.g. for (let i = 0; i < 10; i++) { // i is only available within the loop block scope
+        this.pushScope()
+
+        if (node.type === 'ForStatement' && node.init?.type === 'VariableDeclaration') {
+          for (const decl of node.init.declarations) {
+            this.declarePattern(decl.id, node.init)
+          }
+        }
+        else if ((node.type === 'ForOfStatement' || node.type === 'ForInStatement') && node.left.type === 'VariableDeclaration') {
+          for (const decl of node.left.declarations) {
+            this.declarePattern(decl.id, node.left)
+          }
+        }
+        break
+    }
+  }
+
+  protected processNodeLeave(node: Node) {
+    switch (node.type) {
+      case 'Program':
+      case 'BlockStatement':
+      case 'CatchClause':
+      case 'FunctionDeclaration':
+      case 'ArrowFunctionExpression':
+      case 'StaticBlock':
+      case 'ClassExpression':
+      case 'ForStatement':
+      case 'ForOfStatement':
+      case 'ForInStatement':
+        this.popScope()
+        break
+      case 'FunctionExpression':
+        this.popScope()
+        this.popScope()
+        break
+    }
+  }
+
+  isDeclared(name: string) {
+    if (!this.scopeIndexKey) {
+      return this.scopes.get('')?.has(name) || false
+    }
+
+    const indices = this.scopeIndexKey.split('-').map(Number)
+    for (let i = indices.length; i >= 0; i--) {
+      if (this.scopes.get(indices.slice(0, i).join('-'))?.has(name)) {
+        return true
+      }
+    }
+    return false
+  }
+
+  getDeclaration(name: string): ScopeTrackerNode | null {
+    if (!this.scopeIndexKey) {
+      return this.scopes.get('')?.get(name) ?? null
+    }
+
+    const indices = this.scopeIndexKey.split('-').map(Number)
+    for (let i = indices.length; i >= 0; i--) {
+      const node = this.scopes.get(indices.slice(0, i).join('-'))?.get(name)
+      if (node) {
+        return node
+      }
+    }
+    return null
+  }
+
+  getCurrentScope() {
+    return this.scopeIndexKey
+  }
+
+  /**
+   * Check if the current scope is a child of a specific scope.
+   * @example
+   * ```ts
+   * // current scope is 0-1
+   * isCurrentScopeUnder('0') // true
+   * isCurrentScopeUnder('0-1') // false
+   * ```
+   *
+   * @param scope the parent scope
+   * @returns `true` if the current scope is a child of the specified scope, `false` otherwise (also when they are the same)
+   */
+  isCurrentScopeUnder(scope: string) {
+    return isChildScope(this.scopeIndexKey, scope)
+  }
+
+  /**
+   * Freezes the scope tracker, preventing further declarations.
+   * It also resets the scope index stack to its initial state, so that the scope tracker can be reused.
+   *
+   * This is useful for second passes through the AST.
+   */
+  freeze() {
+    this.isFrozen = true
+    this.scopeIndexStack = []
+    this.updateScopeIndexKey()
+  }
+}
+
+function getPatternIdentifiers(pattern: Node) {
+  const identifiers: Identifier[] = []
+
+  function collectIdentifiers(pattern: Node) {
+    switch (pattern.type) {
+      case 'Identifier':
+        identifiers.push(pattern)
+        break
+      case 'AssignmentPattern':
+        collectIdentifiers(pattern.left)
+        break
+      case 'RestElement':
+        collectIdentifiers(pattern.argument)
+        break
+      case 'ArrayPattern':
+        for (const element of pattern.elements) {
+          if (element) {
+            collectIdentifiers(element.type === 'RestElement' ? element.argument : element)
+          }
+        }
+        break
+      case 'ObjectPattern':
+        for (const property of pattern.properties) {
+          collectIdentifiers(property.type === 'RestElement' ? property.argument : property.value)
+        }
+        break
+    }
+  }
+
+  collectIdentifiers(pattern)
+
+  return identifiers
+}
+
+export function isBindingIdentifier(node: Node, parent: Node | null) {
+  if (!parent || node.type !== 'Identifier') {
+    return false
+  }
+
+  switch (parent.type) {
+    case 'FunctionDeclaration':
+    case 'FunctionExpression':
+    case 'ArrowFunctionExpression':
+      // function name or parameters
+      if (parent.type !== 'ArrowFunctionExpression' && parent.id === node) {
+        return true
+      }
+      if (parent.params.length) {
+        for (const param of parent.params) {
+          const identifiers = getPatternIdentifiers(param)
+          if (identifiers.includes(node)) {
+            return true
+          }
+        }
+      }
+      return false
+
+    case 'ClassDeclaration':
+    case 'ClassExpression':
+      // class name
+      return parent.id === node
+
+    case 'MethodDefinition':
+      // class method name
+      return parent.key === node
+
+    case 'PropertyDefinition':
+      // class property name
+      return parent.key === node
+
+    case 'VariableDeclarator':
+      // variable name
+      return getPatternIdentifiers(parent.id).includes(node)
+
+    case 'CatchClause':
+      // catch clause param
+      if (!parent.param) {
+        return false
+      }
+      return getPatternIdentifiers(parent.param).includes(node)
+
+    case 'Property':
+      // property key if not used as a shorthand
+      return parent.key === node && parent.value !== node
+
+    case 'MemberExpression':
+      // member expression properties
+      return parent.property === node
+  }
+
+  return false
+}
+
+export function getUndeclaredIdentifiersInFunction(node: Function | ArrowFunctionExpression) {
+  const scopeTracker = new ScopeTracker({
+    keepExitedScopes: true,
+  })
+  const undeclaredIdentifiers = new Set<string>()
+
+  function isIdentifierUndeclared(node: IdentifierReference, parent: Node | null) {
+    return !isBindingIdentifier(node, parent) && !scopeTracker.isDeclared(node.name)
+  }
+
+  // first pass to collect all declarations and hoist them
+  walk(node, {
+    scope: scopeTracker,
+  })
+
+  scopeTracker.freeze()
+
+  walk(node, {
+    scope: scopeTracker,
+    enter(node, parent) {
+      if (node.type === 'Identifier' && isIdentifierUndeclared(node, parent)) {
+        undeclaredIdentifiers.add(node.name)
+      }
+    },
+  })
+
+  return Array.from(undeclaredIdentifiers)
+}
+
+/**
+ * A function to check whether scope A is a child of scope B.
+ * @example
+ * ```ts
+ * isChildScope('0-1-2', '0-1') // true
+ * isChildScope('0-1', '0-1') // false
+ * ```
+ *
+ * @param a the child scope
+ * @param b the parent scope
+ * @returns true if scope A is a child of scope B, false otherwise (also when they are the same)
+ */
+function isChildScope(a: string, b: string) {
+  return a.startsWith(b) && a.length > b.length
+}
+
+abstract class BaseNode<T extends Node = Node> {
+  abstract type: string
+  readonly scope: string
+  node: T
+
+  constructor(node: T, scope: string) {
+    this.node = node
+    this.scope = scope
+  }
+
+  /**
+   * The starting position of the entire relevant node in the code.
+   * For instance, for a function parameter, this would be the start of the function declaration.
+   */
+  abstract get start(): number
+
+  /**
+   * The ending position of the entire relevant node in the code.
+   * For instance, for a function parameter, this would be the end of the function declaration.
+   */
+  abstract get end(): number
+
+  /**
+   * Check if the node is defined under a specific scope.
+   * @param scope
+   */
+  isUnderScope(scope: string) {
+    return isChildScope(this.scope, scope)
+  }
+}
+
+class ScopeTrackerIdentifier extends BaseNode<Identifier> {
+  override type = 'Identifier' as const
+
+  get start() {
+    return this.node.start
+  }
+
+  get end() {
+    return this.node.end
+  }
+}
+
+class ScopeTrackerFunctionParam extends BaseNode {
+  type = 'FunctionParam' as const
+  fnNode: Function | ArrowFunctionExpression
+
+  constructor(node: Node, scope: string, fnNode: Function | ArrowFunctionExpression) {
+    super(node, scope)
+    this.fnNode = fnNode
+  }
+
+  get start() {
+    return this.fnNode.start
+  }
+
+  get end() {
+    return this.fnNode.end
+  }
+}
+
+class ScopeTrackerFunction extends BaseNode<Function | ArrowFunctionExpression> {
+  type = 'Function' as const
+
+  get start() {
+    return this.node.start
+  }
+
+  get end() {
+    return this.node.end
+  }
+}
+
+class ScopeTrackerVariable extends BaseNode<Identifier> {
+  type = 'Variable' as const
+  variableNode: VariableDeclaration
+
+  constructor(node: Identifier, scope: string, variableNode: VariableDeclaration) {
+    super(node, scope)
+    this.variableNode = variableNode
+  }
+
+  get start() {
+    return this.variableNode.start
+  }
+
+  get end() {
+    return this.variableNode.end
+  }
+}
+
+class ScopeTrackerImport extends BaseNode<ImportDeclarationSpecifier> {
+  type = 'Import' as const
+  importNode: Node
+
+  constructor(node: ImportDeclarationSpecifier, scope: string, importNode: Node) {
+    super(node, scope)
+    this.importNode = importNode
+  }
+
+  get start() {
+    return this.importNode.start
+  }
+
+  get end() {
+    return this.importNode.end
+  }
+}
+
+class ScopeTrackerCatchParam extends BaseNode {
+  type = 'CatchParam' as const
+  catchNode: CatchClause
+
+  constructor(node: Node, scope: string, catchNode: CatchClause) {
+    super(node, scope)
+    this.catchNode = catchNode
+  }
+
+  get start() {
+    return this.catchNode.start
+  }
+
+  get end() {
+    return this.catchNode.end
+  }
+}
+
+export type ScopeTrackerNode =
+  | ScopeTrackerFunctionParam
+  | ScopeTrackerFunction
+  | ScopeTrackerVariable
+  | ScopeTrackerIdentifier
+  | ScopeTrackerImport
+  | ScopeTrackerCatchParam
+
+interface ScopeTrackerOptions {
+  /**
+   * If true, the scope tracker will keep exited scopes in memory.
+   * This is necessary when you want to do a pre-pass to collect all identifiers before walking, for example.
+   * @default false
+   */
+  keepExitedScopes?: boolean
+}

--- a/test/scope-tracker.test.ts
+++ b/test/scope-tracker.test.ts
@@ -1,0 +1,785 @@
+import { assert, describe, expect, it } from 'vitest'
+import { parseAndWalk } from '../src'
+import { getUndeclaredIdentifiersInFunction, ScopeTracker } from '../src/scope-tracker'
+
+const filename = 'test.ts'
+
+describe('scope tracker', () => {
+  it('should throw away exited scopes', () => {
+    const code = `
+    const a = 1
+    {
+      const b = 2
+    }
+    `
+
+    const scopeTracker = new TestScopeTracker()
+
+    parseAndWalk(code, filename, {
+      scope: scopeTracker,
+    })
+
+    expect(scopeTracker.getScopes().size).toBe(0)
+  })
+
+  it ('should keep exited scopes', () => {
+    const code = `
+    const a = 1
+    {
+      const b = 2
+    }
+    `
+
+    const scopeTracker = new TestScopeTracker({ keepExitedScopes: true })
+
+    parseAndWalk(code, filename, {
+      scope: scopeTracker,
+    })
+
+    expect(scopeTracker.getScopes().size).toBe(2)
+  })
+
+  it('should generate scope key correctly and not allocate unnecessary scopes', () => {
+    const code = `
+    // starting in global scope ("")
+    const a = 1
+    // pushing scope for function parameters ("0")
+    // pushing scope for function body ("0-0")
+    function foo (param) {
+      const b = 2
+      // pushing scope for for loop variable declaration ("0-0-0")
+      // pushing scope for for loop body ("0-0-0-0")
+      for (let i = 0; i < 10; i++) {
+        const c = 3
+
+        // pushing scope for block statement ("0-0-0-0-0")
+        try {
+          const d = 4
+        }
+        // in for loop body scope ("0-0-0-0")
+        // pushing scope for catch clause param ("0-0-0-0-1")
+        // pushing scope for block statement ("0-0-0-0-1-0")
+        catch (e) {
+          const f = 4
+        }
+
+        // in for loop body scope ("0-0-0-0")
+
+        const cc = 3
+      }
+
+      // in function body scope ("0-0")
+
+      // pushing scope for for of loop variable declaration ("0-0-1")
+      // pushing scope for for of loop body ("0-0-1-0")
+      for (const i of [1, 2, 3]) {
+        const dd = 3
+      }
+
+      // in function body scope ("0-0")
+
+      // pushing scope for for in loop variable declaration ("0-0-2")
+      // pushing scope for for in loop body ("0-0-2-0")
+      for (const i in [1, 2, 3]) {
+        const ddd = 3
+      }
+
+      // in function body scope ("0-0")
+
+      // pushing scope for while loop body ("0-0-3")
+      while (true) {
+        const e = 3
+      }
+    }
+
+    // in global scope ("")
+
+    // pushing scope for function expression name ("1")
+    // pushing scope for function parameters ("1-0")
+    // pushing scope for function body ("1-0-0")
+    const baz = function bar (param) {
+      const g = 5
+
+      // pushing scope for block statement ("1-0-0-0")
+      if (true) {
+        const h = 6
+      }
+    }
+
+    // in global scope ("")
+
+    // pushing scope for function expression name ("2")
+    {
+      const i = 7
+      // pushing scope for block statement ("2-0")
+      {
+        const j = 8
+      }
+    }
+
+    // in global scope ("")
+
+    // pushing scope for arrow function parameters ("3")
+    // pushing scope for arrow function body ("3-0")
+    const arrow = (param) => {
+      const k = 9
+    }
+
+    // in global scope ("")
+
+    // pushing scope for class expression name ("4")
+    const classExpression = class InternalClassName {
+      classAttribute = 10
+      // pushing scope for constructor function expression name ("4-0")
+      // pushing scope for constructor parameters ("4-0-0")
+      // pushing scope for constructor body ("4-0-0-0")
+      constructor(constructorParam) {
+        const l = 10
+      }
+
+      // in class body scope ("4")
+
+      // pushing scope for static block ("4-1")
+      static {
+        const m = 11
+      }
+    }
+
+    // in global scope ("")
+
+    class NoScopePushedForThis {
+      // pushing scope for constructor function expression name ("5")
+      // pushing scope for constructor parameters ("5-0")
+      // pushing scope for constructor body ("5-0-0")
+      constructor() {
+        const n = 12
+      }
+    }
+
+    `
+
+    const scopeTracker = new TestScopeTracker({
+      keepExitedScopes: true,
+    })
+
+    // is in global scope initially
+    expect(scopeTracker.getScopeIndexKey()).toBe('')
+
+    parseAndWalk(code, filename, {
+      scope: scopeTracker,
+    })
+
+    // is in global scope after parsing
+    expect(scopeTracker.getScopeIndexKey()).toBe('')
+
+    // check that the scopes are correct
+    const scopes = scopeTracker.getScopes()
+
+    const expectedScopesInOrder = [
+      '',
+      '0',
+      '0-0',
+      '0-0-0',
+      '0-0-0-0',
+      '0-0-0-0-0',
+      '0-0-0-0-1',
+      '0-0-0-0-1-0',
+      '0-0-1',
+      '0-0-1-0',
+      '0-0-2',
+      '0-0-2-0',
+      '0-0-3',
+      '1',
+      '1-0',
+      '1-0-0',
+      '1-0-0-0',
+      '2',
+      '2-0',
+      '3',
+      '3-0',
+      '4',
+      // '4-0', -> DO NOT UNCOMMENT - class constructor method definition doesn't provide a function expression id (scope doesn't have any identifiers)
+      '4-0-0',
+      '4-0-0-0',
+      '4-1',
+      // '5',   -> DO NOT UNCOMMENT - class constructor - same as above
+      // '5-0', -> DO NOT UNCOMMENT - class constructor parameters (none in this case, so the scope isn't stored)
+      '5-0-0',
+    ]
+
+    expect(scopes.size).toBe(expectedScopesInOrder.length)
+
+    const scopeKeys = Array.from(scopes.keys())
+
+    expect(scopeKeys).toEqual(expectedScopesInOrder)
+  })
+
+  it ('should track variable declarations', () => {
+    const code = `
+    const a = 1
+    let x, y = 2
+
+    {
+      let b = 2
+    }
+    `
+
+    const scopeTracker = new TestScopeTracker({
+      keepExitedScopes: true,
+    })
+
+    parseAndWalk(code, filename, {
+      scope: scopeTracker,
+    })
+
+    const scopes = scopeTracker.getScopes()
+
+    const globalScope = scopes.get('')
+    expect(globalScope?.get('a')?.type).toEqual('Variable')
+    expect(globalScope?.get('b')).toBeUndefined()
+    expect(globalScope?.get('x')?.type).toEqual('Variable')
+    expect(globalScope?.get('y')?.type).toEqual('Variable')
+
+    const blockScope = scopes.get('0')
+    expect(blockScope?.get('b')?.type).toEqual('Variable')
+    expect(blockScope?.get('a')).toBeUndefined()
+    expect(blockScope?.get('x')).toBeUndefined()
+    expect(blockScope?.get('y')).toBeUndefined()
+
+    expect(scopeTracker.isDeclaredInScope('a', '')).toBe(true)
+    expect(scopeTracker.isDeclaredInScope('a', '0')).toBe(true)
+    expect(scopeTracker.isDeclaredInScope('y', '')).toBe(true)
+    expect(scopeTracker.isDeclaredInScope('y', '0')).toBe(true)
+
+    expect(scopeTracker.isDeclaredInScope('b', '')).toBe(false)
+    expect(scopeTracker.isDeclaredInScope('b', '0')).toBe(true)
+  })
+
+  it ('should separate variables in different scopes', () => {
+    const code = `
+    const a = 1
+
+    {
+      let a = 2
+    }
+
+    function foo (a) {
+      // scope "1-0"
+      let b = a
+    }
+    `
+
+    const scopeTracker = new TestScopeTracker({
+      keepExitedScopes: true,
+    })
+
+    parseAndWalk(code, filename, {
+      scope: scopeTracker,
+    })
+
+    const globalA = scopeTracker.getDeclarationFromScope('a', '')
+    expect(globalA?.type).toEqual('Variable')
+    expect(globalA?.type === 'Variable' && globalA.variableNode.type).toEqual('VariableDeclaration')
+
+    const blockA = scopeTracker.getDeclarationFromScope('a', '0')
+    expect(blockA?.type).toEqual('Variable')
+    expect(blockA?.type === 'Variable' && blockA.variableNode.type).toEqual('VariableDeclaration')
+
+    // check that the two `a` variables are different
+    expect(globalA?.type === 'Variable' && globalA.variableNode).not.toBe(blockA?.type === 'Variable' && blockA.variableNode)
+
+    // check that the `a` in the function scope is a function param and not a variable
+    const fooA = scopeTracker.getDeclarationFromScope('a', '1-0')
+    expect(fooA?.type).toEqual('FunctionParam')
+  })
+
+  it ('should handle patterns', () => {
+    const code = `
+    const { a, b: c } = { a: 1, b: 2 }
+    const [d, [e]] = [3, [4]]
+    const { f: { g } } = { f: { g: 5 } }
+
+    function foo ({ h, i: j } = {}, [k, [l, m], ...rest]) {
+    }
+
+    try {} catch ({ message }) {}
+    `
+
+    const scopeTracker = new TestScopeTracker({
+      keepExitedScopes: true,
+    })
+
+    parseAndWalk(code, filename, {
+      scope: scopeTracker,
+    })
+
+    const scopes = scopeTracker.getScopes()
+    expect(scopes.size).toBe(3)
+
+    const globalScope = scopes.get('')
+    expect(globalScope?.size).toBe(6)
+
+    expect(globalScope?.get('a')?.type).toEqual('Variable')
+    expect(globalScope?.get('b')?.type).toBeUndefined()
+    expect(globalScope?.get('c')?.type).toEqual('Variable')
+    expect(globalScope?.get('d')?.type).toEqual('Variable')
+    expect(globalScope?.get('e')?.type).toEqual('Variable')
+    expect(globalScope?.get('f')?.type).toBeUndefined()
+    expect(globalScope?.get('g')?.type).toEqual('Variable')
+    expect(globalScope?.get('foo')?.type).toEqual('Function')
+
+    const fooScope = scopes.get('0')
+    expect(fooScope?.size).toBe(6)
+
+    expect(fooScope?.get('h')?.type).toEqual('FunctionParam')
+    expect(fooScope?.get('i')?.type).toBeUndefined()
+    expect(fooScope?.get('j')?.type).toEqual('FunctionParam')
+    expect(fooScope?.get('k')?.type).toEqual('FunctionParam')
+    expect(fooScope?.get('l')?.type).toEqual('FunctionParam')
+    expect(fooScope?.get('m')?.type).toEqual('FunctionParam')
+    expect(fooScope?.get('rest')?.type).toEqual('FunctionParam')
+
+    const catchScope = scopes.get('2')
+    expect(catchScope?.size).toBe(1)
+    expect(catchScope?.get('message')?.type).toEqual('CatchParam')
+
+    expect(scopeTracker.isDeclaredInScope('a', '')).toBe(true)
+    expect(scopeTracker.isDeclaredInScope('b', '')).toBe(false)
+    expect(scopeTracker.isDeclaredInScope('c', '')).toBe(true)
+    expect(scopeTracker.isDeclaredInScope('d', '')).toBe(true)
+    expect(scopeTracker.isDeclaredInScope('e', '')).toBe(true)
+    expect(scopeTracker.isDeclaredInScope('f', '')).toBe(false)
+    expect(scopeTracker.isDeclaredInScope('g', '')).toBe(true)
+    expect(scopeTracker.isDeclaredInScope('h', '0')).toBe(true)
+    expect(scopeTracker.isDeclaredInScope('i', '0')).toBe(false)
+    expect(scopeTracker.isDeclaredInScope('j', '0')).toBe(true)
+    expect(scopeTracker.isDeclaredInScope('k', '0')).toBe(true)
+    expect(scopeTracker.isDeclaredInScope('l', '0')).toBe(true)
+    expect(scopeTracker.isDeclaredInScope('m', '0')).toBe(true)
+    expect(scopeTracker.isDeclaredInScope('rest', '0')).toBe(true)
+    expect(scopeTracker.isDeclaredInScope('message', '2')).toBe(true)
+  })
+
+  it ('should handle loops', () => {
+    const code = `
+    for (let i = 0, getI = () => i; i < 3; i++) {
+      console.log(getI());
+    }
+
+    let j = 0;
+    for (; j < 3; j++) { }
+
+    const obj = { a: 1, b: 2, c: 3 }
+    for (const property in obj) { }
+
+    const arr = ['a', 'b', 'c']
+    for (const element of arr) { }
+    `
+
+    const scopeTracker = new TestScopeTracker({
+      keepExitedScopes: true,
+    })
+
+    parseAndWalk(code, filename, {
+      scope: scopeTracker,
+    })
+
+    const scopes = scopeTracker.getScopes()
+    expect(scopes.size).toBe(4)
+
+    const globalScope = scopes.get('')
+    expect(globalScope?.size).toBe(3)
+    expect(globalScope?.get('j')?.type).toEqual('Variable')
+    expect(globalScope?.get('obj')?.type).toEqual('Variable')
+    expect(globalScope?.get('arr')?.type).toEqual('Variable')
+
+    const forScope1 = scopes.get('0')
+    expect(forScope1?.size).toBe(2)
+    expect(forScope1?.get('i')?.type).toEqual('Variable')
+    expect(forScope1?.get('getI')?.type).toEqual('Variable')
+
+    const forScope2 = scopes.get('1')
+    expect(forScope2).toBeUndefined()
+
+    const forScope3 = scopes.get('2')
+    expect(forScope3?.size).toBe(1)
+    expect(forScope3?.get('property')?.type).toEqual('Variable')
+
+    const forScope4 = scopes.get('3')
+    expect(forScope4?.size).toBe(1)
+    expect(forScope4?.get('element')?.type).toEqual('Variable')
+
+    expect(scopeTracker.isDeclaredInScope('i', '')).toBe(false)
+    expect(scopeTracker.isDeclaredInScope('getI', '')).toBe(false)
+    expect(scopeTracker.isDeclaredInScope('i', '0-0')).toBe(true)
+    expect(scopeTracker.isDeclaredInScope('getI', '0-0')).toBe(true)
+    expect(scopeTracker.isDeclaredInScope('j', '')).toBe(true)
+    expect(scopeTracker.isDeclaredInScope('j', '1-0')).toBe(true)
+    expect(scopeTracker.isDeclaredInScope('property', '')).toBe(false)
+    expect(scopeTracker.isDeclaredInScope('element', '')).toBe(false)
+  })
+
+  it ('should handle imports', () => {
+    const code = `
+    import { a, b as c } from 'module-a'
+    import d from 'module-b'
+    `
+
+    const scopeTracker = new TestScopeTracker({
+      keepExitedScopes: true,
+    })
+
+    parseAndWalk(code, filename, {
+      scope: scopeTracker,
+    })
+
+    expect(scopeTracker.isDeclaredInScope('a', '')).toBe(true)
+    expect(scopeTracker.isDeclaredInScope('b', '')).toBe(false)
+    expect(scopeTracker.isDeclaredInScope('c', '')).toBe(true)
+    expect(scopeTracker.isDeclaredInScope('d', '')).toBe(true)
+
+    expect(scopeTracker.getScopes().get('')?.size).toBe(3)
+  })
+
+  it ('should handle classes', () => {
+    const code = `
+    // ""
+
+    class Foo {
+      someProperty = 1
+
+      // "0" - function expression name
+      // "0-0" - constructor parameters
+      // "0-0-0" - constructor body
+      constructor(param) {
+        let a = 1
+        this.b = 1
+      }
+
+      // "1" - method name
+      // "1-0" - method parameters
+      // "1-0-0" - method body
+      someMethod(param) {
+        let c = 1
+      }
+
+      // "2" - method name
+      // "2-0" - method parameters
+      // "2-0-0" - method body
+      get d() {
+        let e = 1
+        return 1
+      }
+    }
+    `
+
+    const scopeTracker = new TestScopeTracker({
+      keepExitedScopes: true,
+    })
+
+    parseAndWalk(code, filename, {
+      scope: scopeTracker,
+    })
+
+    const scopes = scopeTracker.getScopes()
+
+    // only the scopes containing identifiers are stored
+    const expectedScopes = [
+      '',
+      '0-0',
+      '0-0-0',
+      '1-0',
+      '1-0-0',
+      '2-0-0',
+    ]
+
+    expect(scopes.size).toBe(expectedScopes.length)
+
+    const scopeKeys = Array.from(scopes.keys())
+    expect(scopeKeys).toEqual(expectedScopes)
+
+    expect(scopeTracker.isDeclaredInScope('Foo', '')).toBe(true)
+
+    // properties should be accessible through the class
+    expect(scopeTracker.isDeclaredInScope('someProperty', '')).toBe(false)
+    expect(scopeTracker.isDeclaredInScope('someProperty', '0')).toBe(false)
+
+    expect(scopeTracker.isDeclaredInScope('a', '0-0-0')).toBe(true)
+    expect(scopeTracker.isDeclaredInScope('b', '0-0-0')).toBe(false)
+
+    // method definitions don't have names in function expressions, so it is not stored
+    // they should be accessed through the class
+    expect(scopeTracker.isDeclaredInScope('someMethod', '1')).toBe(false)
+    expect(scopeTracker.isDeclaredInScope('someMethod', '1-0-0')).toBe(false)
+    expect(scopeTracker.isDeclaredInScope('someMethod', '')).toBe(false)
+    expect(scopeTracker.isDeclaredInScope('c', '1-0-0')).toBe(true)
+
+    expect(scopeTracker.isDeclaredInScope('d', '2')).toBe(false)
+    expect(scopeTracker.isDeclaredInScope('d', '2-0-0')).toBe(false)
+    expect(scopeTracker.isDeclaredInScope('d', '')).toBe(false)
+    expect(scopeTracker.isDeclaredInScope('e', '2-0-0')).toBe(true)
+  })
+
+  it ('should freeze scopes', () => {
+    let code = `
+    const a = 1
+    {
+      const b = 2
+    }
+    `
+
+    const scopeTracker = new TestScopeTracker({
+      keepExitedScopes: true,
+    })
+
+    parseAndWalk(code, filename, {
+      scope: scopeTracker,
+    })
+
+    expect(scopeTracker.getScopes().size).toBe(2)
+
+    code = `${code}\n` + `
+      {
+        const c = 3
+      }
+    `
+
+    parseAndWalk(code, filename, {
+      scope: scopeTracker,
+    })
+
+    expect(scopeTracker.getScopes().size).toBe(3)
+
+    scopeTracker.freeze()
+
+    code = `${code}\n` + `
+      {
+        const d = 4
+      }
+    `
+
+    parseAndWalk(code, filename, {
+      scope: scopeTracker,
+    })
+
+    expect(scopeTracker.getScopes().size).toBe(3)
+
+    expect(scopeTracker.isDeclaredInScope('a', '')).toBe(true)
+    expect(scopeTracker.isDeclaredInScope('b', '0')).toBe(true)
+    expect(scopeTracker.isDeclaredInScope('c', '1')).toBe(true)
+    expect(scopeTracker.isDeclaredInScope('d', '2')).toBe(false)
+  })
+})
+
+describe('parsing', () => {
+  it ('should correctly get identifiers not declared in a function', () => {
+    const functionParams = `(param, { param1, temp: param2 } = {}, [param3, [param4]], ...rest)`
+    const functionBody = `{
+      const c = 1, d = 2
+      console.log(undeclaredIdentifier1, foo)
+      const obj = {
+        key1: param,
+        key2: undeclaredIdentifier1,
+        undeclaredIdentifier2: undeclaredIdentifier2,
+        undeclaredIdentifier3,
+        undeclaredIdentifier4,
+      }
+      nonExistentFunction()
+
+      console.log(a, b, c, d, param, param1, param2, param3, param4, param['test']['key'], rest)
+      console.log(param3[0].access['someKey'], obj, obj.key1, obj.key2, obj.undeclaredIdentifier2, obj.undeclaredIdentifier3)
+
+      try {} catch (error) { console.log(error) }
+
+      class Foo { constructor() { console.log(Foo) } }
+      const cls = class Bar { constructor() { console.log(Bar, cls) } }
+      const cls2 = class Baz {
+        someProperty = someValue
+        someMethod() { }
+      }
+      console.log(Baz)
+
+      function f() {
+        console.log(hoisted, nonHoisted)
+      }
+      let hoisted = 1
+      f()
+    }`
+
+    const code = `
+    import { a } from 'module-a'
+    const b = 1
+
+    // "0"
+    function foo ${functionParams} ${functionBody}
+
+    // "1"
+    const f = ${functionParams} => ${functionBody}
+
+    // "2-0"
+    const bar = function ${functionParams} ${functionBody}
+
+    // "3-0"
+    const baz = function foo ${functionParams} ${functionBody}
+
+    // "4"
+    function emptyParams() {
+      console.log(param)
+    }
+    `
+
+    const scopeTracker = new TestScopeTracker({
+      keepExitedScopes: true,
+    })
+
+    let processedFunctions = 0
+
+    parseAndWalk(code, filename, {
+      scope: scopeTracker,
+      enter: (node) => {
+        const currentScope = scopeTracker.getScopeIndexKey()
+        if ((node.type !== 'FunctionDeclaration' && node.type !== 'FunctionExpression' && node.type !== 'ArrowFunctionExpression') || !['0', '1', '2-0', '3-0', '4'].includes(currentScope)) {
+          return
+        }
+
+        const undeclaredIdentifiers = getUndeclaredIdentifiersInFunction(node)
+        expect(undeclaredIdentifiers).toEqual(currentScope === '4'
+          ? [
+              'console',
+              'param',
+            ]
+          : [
+              'console',
+              'undeclaredIdentifier1',
+              ...(node.type === 'ArrowFunctionExpression' || (node.type === 'FunctionExpression' && !node.id) ? ['foo'] : []),
+              'undeclaredIdentifier2',
+              'undeclaredIdentifier3',
+              'undeclaredIdentifier4',
+              'nonExistentFunction',
+              'a', // import is outside the scope of the function
+              'b', // variable is outside the scope of the function
+              'someValue',
+              'Baz',
+              'nonHoisted',
+            ])
+
+        processedFunctions++
+      },
+    })
+
+    expect(processedFunctions).toBe(5)
+  })
+
+  it ('should correctly compare identifiers defined in different scopes', () => {
+    const code = `
+      // ""
+      const a = 1
+
+      // ""
+      const func = () => {
+        // "0-0"
+        const b = 2
+
+        // "0-0"
+        function foo() {
+          // "0-0-0-0"
+          const c = 3
+        }
+      }
+
+      // ""
+      const func2 = () => {
+        // "1-0"
+        const d = 2
+
+        // "1-0"
+        function bar() {
+          // "1-0-0-0"
+          const e = 3
+        }
+      }
+
+      // ""
+      const f = 4
+    `
+
+    const scopeTracker = new TestScopeTracker({
+      keepExitedScopes: true,
+    })
+
+    parseAndWalk(code, filename, {
+      scope: scopeTracker,
+    })
+
+    const a = scopeTracker.getDeclarationFromScope('a', '')
+    const func = scopeTracker.getDeclarationFromScope('func', '')
+    const foo = scopeTracker.getDeclarationFromScope('foo', '0-0')
+    const b = scopeTracker.getDeclarationFromScope('b', '0-0')
+    const c = scopeTracker.getDeclarationFromScope('c', '0-0-0-0')
+    const func2 = scopeTracker.getDeclarationFromScope('func2', '')
+    const bar = scopeTracker.getDeclarationFromScope('bar', '1-0')
+    const d = scopeTracker.getDeclarationFromScope('d', '1-0')
+    const e = scopeTracker.getDeclarationFromScope('e', '1-0-0-0')
+    const f = scopeTracker.getDeclarationFromScope('f', '')
+
+    assert(a && func && foo && b && c && func2 && bar && d && e && f, 'All declarations should be found')
+
+    // identifiers in the same scope should be equal
+    expect(f.isUnderScope(a.scope)).toBe(false)
+    expect(func.isUnderScope(a.scope)).toBe(false)
+    expect(d.isUnderScope(bar.scope)).toBe(false)
+
+    // identifiers in deeper scopes should be under the scope of the parent scope
+    expect(b.isUnderScope(a.scope)).toBe(true)
+    expect(b.isUnderScope(func.scope)).toBe(true)
+    expect(c.isUnderScope(a.scope)).toBe(true)
+    expect(c.isUnderScope(b.scope)).toBe(true)
+    expect(d.isUnderScope(a.scope)).toBe(true)
+    expect(d.isUnderScope(func2.scope)).toBe(true)
+    expect(e.isUnderScope(a.scope)).toBe(true)
+    expect(e.isUnderScope(d.scope)).toBe(true)
+
+    // identifiers in parent scope should not be under the scope of the children
+    expect(a.isUnderScope(b.scope)).toBe(false)
+    expect(a.isUnderScope(c.scope)).toBe(false)
+    expect(a.isUnderScope(d.scope)).toBe(false)
+    expect(a.isUnderScope(e.scope)).toBe(false)
+    expect(b.isUnderScope(c.scope)).toBe(false)
+
+    // identifiers in parallel scopes should not influence each other
+    expect(d.isUnderScope(b.scope)).toBe(false)
+    expect(e.isUnderScope(b.scope)).toBe(false)
+    expect(b.isUnderScope(d.scope)).toBe(false)
+    expect(c.isUnderScope(e.scope)).toBe(false)
+  })
+})
+
+export class TestScopeTracker extends ScopeTracker {
+  getScopes() {
+    return this.scopes
+  }
+
+  getScopeIndexKey() {
+    return this.scopeIndexKey
+  }
+
+  getScopeIndexStack() {
+    return this.scopeIndexStack
+  }
+
+  isDeclaredInScope(identifier: string, scope: string) {
+    const oldKey = this.scopeIndexKey
+    this.scopeIndexKey = scope
+    const result = this.isDeclared(identifier)
+    this.scopeIndexKey = oldKey
+    return result
+  }
+
+  getDeclarationFromScope(identifier: string, scope: string) {
+    const oldKey = this.scopeIndexKey
+    this.scopeIndexKey = scope
+    const result = this.getDeclaration(identifier)
+    this.scopeIndexKey = oldKey
+    return result
+  }
+}


### PR DESCRIPTION
Pushing my WIP branch with the adaptation of the scope tracker to `oxc-parser` types.  
This is probably obsolete for now, as we discussed. Feel free to close it if you prefer, or we can leave it open and finalize it later if we eventually decide to switch to `oxc` in Nuxt.