### PR TITLE
ci: use GitHub App token for release-please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -14,7 +14,12 @@ jobs:
       contents: write
       pull-requests: write
     steps:
+      - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        id: app-token
+        with:
+          client-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
       - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           release-type: node


### PR DESCRIPTION
## Summary
- Mint a GitHub App installation token via `actions/create-github-app-token` and pass it to `release-please-action` instead of the default `GITHUB_TOKEN`, fixing the failing release-please run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)