### PR TITLE
ci: pass CODECOV_TOKEN and point badges at oxc-project

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,3 +53,5 @@ jobs:
 
       - name: 🟩 Coverage
         uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ Published under [MIT License](./LICENCE).
 [npm-version-href]: https://npmx.dev/package/oxc-walker
 [npm-downloads-src]: https://npmx.dev/api/registry/badge/downloads/oxc-walker
 [npm-downloads-href]: https://npm.chart.dev/oxc-walker
-[github-actions-src]: https://img.shields.io/github/actions/workflow/status/danielroe/oxc-walker/ci.yml?branch=main&style=flat-square
-[github-actions-href]: https://github.com/danielroe/oxc-walker/actions?query=workflow%3Aci
-[codecov-src]: https://img.shields.io/codecov/c/gh/danielroe/oxc-walker/main?style=flat-square
-[codecov-href]: https://codecov.io/gh/danielroe/oxc-walker
+[github-actions-src]: https://img.shields.io/github/actions/workflow/status/oxc-project/oxc-walker/ci.yml?branch=main&style=flat-square
+[github-actions-href]: https://github.com/oxc-project/oxc-walker/actions?query=workflow%3Aci
+[codecov-src]: https://img.shields.io/codecov/c/gh/oxc-project/oxc-walker/main?style=flat-square
+[codecov-href]: https://codecov.io/gh/oxc-project/oxc-walker


### PR DESCRIPTION
## Summary

- Pass `secrets.CODECOV_TOKEN` to the Codecov action — uploads were failing on protected branches with `Token required because branch is protected`, which is why the README badge currently shows "unknown".
- Update the GitHub Actions and Codecov badge URLs in `README.md` to point at `oxc-project/oxc-walker` instead of the stale `danielroe/oxc-walker` slug.