### PR TITLE
ci: exclude oxc packages from pnpm minimumReleaseAge gate

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -12,6 +12,14 @@ overrides:
 
 verifyDepsBeforeRun: install
 trustPolicy: no-downgrade
+# oxc packages are published by the oxc project itself, so they are exempt from
+# pnpm 11's default `minimumReleaseAge` (1 day) supply-chain gate. Without this,
+# renovate bumps to a freshly released oxc-parser fail `vp install` in CI until
+# the packages are 24h old.
+minimumReleaseAgeExclude:
+  - oxc-parser
+  - "@oxc-parser/*"
+  - "@oxc-project/*"
 catalog:
   vite: npm:@voidzero-dev/vite-plus-core@latest
   vitest: npm:@voidzero-dev/vite-plus-test@latest


### PR DESCRIPTION
## Problem

renovate PRs that bump `oxc-parser` (e.g. #322 → `oxc-parser@0.138.0`) fail CI at the `vp install` step:

```
[ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION] 22 lockfile entries failed verification:
  @oxc-parser/binding-*@0.138.0 was published at ..., within the minimumReleaseAge cutoff
```

pnpm 11 enables `minimumReleaseAge: 1440` (1 day) by default, and `vp install` verifies the lockfile against it. The shared renovate preset bumps the `oxc` group only `1 hour` after release, so the freshly published `oxc-parser` / `@oxc-parser/*` / `@oxc-project/*` packages get rejected as too new — `vp install` fails for ~23h until they age past the gate.

## Fix

These packages are published by the oxc project itself, so they don't need the supply-chain maturity window. Exempt them via `minimumReleaseAgeExclude`. The 1-day gate still protects all third-party dependencies.

## Verification

- `vp install` lockfile verification passes; confirmed under an exaggerated age gate that `oxc-parser`/`@oxc-parser/*`/`@oxc-project/*` are the only entries skipped.
- Locally bumped to `oxc-parser@0.138.0`: `build`, `tsc --noEmit`, and the walker AST integration (`TSTypeAnnotation` / JSX `sourceType`) all pass — the `0.137.0` "TS fields as a runtime option" change does not affect oxc-walker.