### PR TITLE
fix: use `@oxc-project/types` for ast types

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "magic-regexp": "^0.11.0"
   },
   "devDependencies": {
+    "@oxc-project/types": "0.139.0",
     "@types/node": "24.10.3",
     "@vitest/coverage-v8": "4.1.10",
     "knip": "^6.0.0",
@@ -42,10 +43,14 @@
     "vite-plus": "catalog:"
   },
   "peerDependencies": {
+    "@oxc-project/types": ">=0.98.0",
     "oxc-parser": ">=0.98.0",
     "rolldown": ">=1.0.0"
   },
   "peerDependenciesMeta": {
+    "@oxc-project/types": {
+      "optional": true
+    },
     "oxc-parser": {
       "optional": true
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,6 +25,9 @@ importers:
         specifier: '>=1.0.0'
         version: 1.0.0
     devDependencies:
+      '@oxc-project/types':
+        specifier: 0.139.0
+        version: 0.139.0
       '@types/node':
         specifier: 24.10.3
         version: 24.10.3

--- a/src/scope-tracker.ts
+++ b/src/scope-tracker.ts
@@ -7,7 +7,7 @@ import type {
   ImportDeclarationSpecifier,
   Node,
   VariableDeclaration,
-} from "oxc-parser";
+} from "@oxc-project/types";
 import type { Identifier } from "./walk";
 import { walk } from "./walk";
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,4 @@
-import type { Node } from "oxc-parser";
+import type { Node } from "@oxc-project/types";
 
 export function isNode(v: unknown): v is Node {
   return (

--- a/src/walk.ts
+++ b/src/walk.ts
@@ -4,11 +4,10 @@ import type {
   IdentifierReference,
   LabelIdentifier,
   Node,
-  ParseResult,
-  ParserOptions,
   Program,
   TSIndexSignatureName,
-} from "oxc-parser";
+} from "@oxc-project/types";
+import type { ParseResult, ParserOptions } from "oxc-parser";
 import type { WalkerEnter } from "./walker/base";
 import type { WalkOptions } from "./walker/sync";
 import { createRequire } from "node:module";

--- a/src/walker/base.ts
+++ b/src/walker/base.ts
@@ -1,4 +1,4 @@
-import type { Node, Program } from "oxc-parser";
+import type { Node, Program } from "@oxc-project/types";
 import type { ScopeTracker, ScopeTrackerProtected } from "../scope-tracker";
 
 export interface WalkerCallbackContext {

--- a/src/walker/sync.ts
+++ b/src/walker/sync.ts
@@ -1,4 +1,4 @@
-import type { Node } from "oxc-parser";
+import type { Node } from "@oxc-project/types";
 import type { ScopeTracker } from "../scope-tracker";
 import type { WalkerCallbackContext, WalkerEnter, WalkerLeave, WalkerOptions } from "./base";
 import { isNode } from "../utils";


### PR DESCRIPTION
related: https://github.com/oxc-project/oxc-walker/pull/288

previously we required `oxc-parser` to be installed for types, but this can lead to type mismatches if the user has an older version of `oxc-parser` installed for some reason (see https://github.com/nuxt/nuxt/pull/35543 for example)