### PR TITLE
ci: drop redundant global npm install before pnpm publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,8 +40,6 @@ jobs:
 
       - uses: voidzero-dev/setup-vp@250f29ce396baf5e8f24498e17c0dfdebabc26eb # v1.15.0
 
-      - run: npm install -g npm@latest # For trusted publishing support
-
       - name: Publish to npm
         run: pnpm publish --provenance --access public
 


### PR DESCRIPTION
Removes the redundant `npm install -g npm@latest` step. Publishing already uses `pnpm publish`, so the globally-installed npm version has no effect and the step can be dropped.