### PR TITLE
perf: remove magic-regexp dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,9 +30,6 @@
     "test:unit": "vp test",
     "test:types": "tsc --noEmit"
   },
-  "dependencies": {
-    "magic-regexp": "^0.11.0"
-  },
   "devDependencies": {
     "@oxc-project/types": "0.141.0",
     "@types/node": "24.10.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,9 +18,6 @@ importers:
 
   .:
     dependencies:
-      magic-regexp:
-        specifier: ^0.11.0
-        version: 0.11.0
       rolldown:
         specifier: '>=1.0.0'
         version: 1.0.0
@@ -1686,9 +1683,6 @@ packages:
     resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
     hasBin: true
 
-  magic-regexp@0.11.0:
-    resolution: {integrity: sha512-LG77Z/gVnwz7oaDpD4heX6ryl+lcr4l1B2gnP4MMvt2pGhGC1Dfj7dl1pXpP4ih+VQFLuAadeKVa+lARAzfW+Q==}
-
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
@@ -3074,13 +3068,6 @@ snapshots:
       lightningcss-win32-x64-msvc: 1.32.0
 
   lz-string@1.5.0: {}
-
-  magic-regexp@0.11.0:
-    dependencies:
-      magic-string: 0.30.21
-      regexp-tree: 0.1.27
-      type-level-regexp: 0.1.17
-      unplugin: 3.0.0
 
   magic-string@0.30.21:
     dependencies:

--- a/src/walk.ts
+++ b/src/walk.ts
@@ -11,7 +11,6 @@ import type { ParseResult, ParserOptions } from "oxc-parser";
 import type { WalkerEnter } from "./walker/base";
 import type { WalkOptions } from "./walker/sync";
 import { createRequire } from "node:module";
-import { anyOf, createRegExp, exactly } from "magic-regexp/further-magic";
 import { WalkerSync } from "./walker/sync";
 
 type ParseSync = (
@@ -79,15 +78,7 @@ interface ParseAndWalkOptions extends WalkOptions {
   parseSync: ParseSync;
 }
 
-const LANG_RE = createRegExp(
-  exactly("jsx")
-    .or("tsx")
-    .or("js")
-    .or("ts")
-    .groupedAs("lang")
-    .after(exactly(".").and(anyOf("c", "m").optionally()))
-    .at.lineEnd(),
-);
+const LANG_RE = /\.(?:c|m)?(?<lang>jsx?|tsx?)$/;
 
 /**
  * Parse the code and walk the AST with the given callback, which is called when entering a node.

--- a/test/walker.test.ts
+++ b/test/walker.test.ts
@@ -340,16 +340,22 @@ describe("oxc-walker", () => {
     );
   });
 
-  it("handles language extensions in path", () => {
-    let didEncounterTypescript = false;
-    parseAndWalk("const foo: number = 1", "directory.js/file.ts", {
-      enter(node) {
-        if (node.type === "TSTypeAnnotation") {
-          didEncounterTypescript = true;
-        }
-      },
-    });
-    expect(didEncounterTypescript).toBe(true);
+  it.each([
+    ["js", "const foo = 1"],
+    ["cjs", "const foo = 1"],
+    ["mjs", "const foo = 1"],
+    ["jsx", "const foo = <div />"],
+    ["cjsx", "const foo = <div />"],
+    ["mjsx", "const foo = <div />"],
+    ["ts", "const foo: number = 1"],
+    ["cts", "const foo: number = 1"],
+    ["mts", "const foo: number = 1"],
+    ["tsx", "const foo: number = <div />"],
+    ["ctsx", "const foo: number = <div />"],
+    ["mtsx", "const foo: number = <div />"],
+  ])("handles .%s language extensions in paths", (extension, code) => {
+    const result = parseAndWalk(code, `directory.js/file.${extension}`, {});
+    expect(result.errors).toEqual([]);
   });
 
   it("accepts options for parsing", () => {


### PR DESCRIPTION
## Summary

Replace the generated language extension regexp with its native equivalent. This removes the package's only runtime dependency while preserving support for JS, JSX, TS, TSX, and their CommonJS and ESM variants.

The extension cases now have direct regression coverage. This came from tracing the install graph for unjs/unhead#916.

## Verification

* `pnpm exec vp check`
* `pnpm exec vp test`, 42 tests
* `pnpm build`
* `pnpm install --frozen-lockfile`
