### PR TITLE
feat: add `isReferenceIdentifier` and `isOnlyBindingIdentifier`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 export {
   getUndeclaredIdentifiersInFunction,
   isBindingIdentifier,
+  isOnlyBindingIdentifier,
   isReferenceIdentifier,
   ScopeTrackerFunctionParam,
   ScopeTrackerFunction,

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,12 @@ export {
   ScopeTrackerCatchParam,
   ScopeTracker,
 } from "./scope-tracker";
-export type { ScopeTrackerOptions, ScopeTrackerNode } from "./scope-tracker";
+export type {
+  ScopeTrackerOptions,
+  ScopeTrackerQueryOptions,
+  ScopeTrackerNode,
+  IsReferenceIdentifierOptions,
+} from "./scope-tracker";
 export type {
   WalkerThisContextEnter,
   WalkerThisContextLeave,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 export {
   getUndeclaredIdentifiersInFunction,
   isBindingIdentifier,
+  isReferenceIdentifier,
   ScopeTrackerFunctionParam,
   ScopeTrackerFunction,
   ScopeTrackerVariable,

--- a/src/scope-tracker.ts
+++ b/src/scope-tracker.ts
@@ -71,6 +71,7 @@ export class ScopeTracker {
   protected scopeIndexStack: number[] = [];
   protected scopeIndexKey = "";
   protected scopes: Map<string, Map<string, ScopeTrackerNode>> = new Map();
+  protected typeScopes: Map<string, Map<string, ScopeTrackerNode>> = new Map();
 
   protected options: Partial<ScopeTrackerOptions>;
   protected isFrozen = false;
@@ -96,22 +97,40 @@ export class ScopeTracker {
 
     if (!this.options.preserveExitedScopes) {
       this.scopes.delete(this.scopeIndexKey);
+      this.typeScopes.delete(this.scopeIndexKey);
     }
 
     this.updateScopeIndexKey();
   }
 
-  protected declareIdentifier(name: string, data: ScopeTrackerNode) {
+  protected declareInNamespace(
+    scopes: Map<string, Map<string, ScopeTrackerNode>>,
+    name: string,
+    data: ScopeTrackerNode,
+  ) {
+    let scope = scopes.get(this.scopeIndexKey);
+    if (!scope) {
+      scope = new Map();
+      scopes.set(this.scopeIndexKey, scope);
+    }
+    scope.set(name, data);
+  }
+
+  protected declareIdentifier(
+    name: string,
+    data: ScopeTrackerNode,
+    namespaces: { value?: boolean; type?: boolean } = { value: true },
+  ) {
     if (this.isFrozen) {
       return;
     }
 
-    let scope = this.scopes.get(this.scopeIndexKey);
-    if (!scope) {
-      scope = new Map();
-      this.scopes.set(this.scopeIndexKey, scope);
+    if (namespaces.value) {
+      this.declareInNamespace(this.scopes, name, data);
     }
-    scope.set(name, data);
+    if (namespaces.type) {
+      this.declareInNamespace(this.typeScopes, name, data);
+    }
   }
 
   protected declareFunctionParameter(param: Node, fn: Function | ArrowFunctionExpression) {
@@ -198,10 +217,12 @@ export class ScopeTracker {
 
       case "ClassDeclaration":
         // declare class name for named classes, skip for `export default`
+        // classes are referencable both as values and as types
         if (node.id?.name) {
           this.declareIdentifier(
             node.id.name,
             new ScopeTrackerIdentifier(node.id, this.scopeIndexKey),
+            { value: true, type: true },
           );
         }
         break;
@@ -214,27 +235,83 @@ export class ScopeTracker {
           this.declareIdentifier(
             node.id.name,
             new ScopeTrackerIdentifier(node.id, this.scopeIndexKey),
+            { value: true, type: true },
           );
         }
         break;
 
       case "ImportDeclaration":
+        // imports are referencable both as values and as types
         for (const specifier of node.specifiers) {
           this.declareIdentifier(
             specifier.local.name,
             new ScopeTrackerImport(specifier, this.scopeIndexKey, node),
+            { value: true, type: true },
           );
         }
         break;
 
       case "TSEnumDeclaration":
       case "TSModuleDeclaration":
-        // enums and namespaces declare a value binding for their name
-        if (node.id.type === "Identifier" && node.id.name) {
+      case "TSImportEqualsDeclaration":
+        // enums, namespaces and `import =` are referencable both as values and as types (except `declare global`, which does not create a binding)
+        if (node.type === "TSModuleDeclaration" && node.kind === "global") {
+          break;
+        }
+        if (node.id?.type === "Identifier" && node.id.name) {
+          this.declareIdentifier(
+            node.id.name,
+            new ScopeTrackerIdentifier(node.id, this.scopeIndexKey),
+            { value: true, type: true },
+          );
+        }
+        break;
+
+      case "TSDeclareFunction":
+        // `declare function` and function overload signatures declare a value binding
+        if (node.id?.name) {
           this.declareIdentifier(
             node.id.name,
             new ScopeTrackerIdentifier(node.id, this.scopeIndexKey),
           );
+        }
+        break;
+
+      case "TSInterfaceDeclaration":
+      case "TSTypeAliasDeclaration":
+        // interfaces and type aliases declare a binding in the type namespace only;
+        // a scope is pushed so that their type parameters do not leak out
+        if (node.id?.name) {
+          this.declareIdentifier(
+            node.id.name,
+            new ScopeTrackerIdentifier(node.id, this.scopeIndexKey),
+            { type: true },
+          );
+        }
+        this.pushScope();
+        break;
+
+      case "TSTypeParameter":
+        // generic type parameters (`function f<T>()`)
+        if (node.name?.name) {
+          this.declareIdentifier(
+            node.name.name,
+            new ScopeTrackerIdentifier(node.name, this.scopeIndexKey),
+            { type: true },
+          );
+        }
+        break;
+
+      case "TSEnumBody":
+        // enum members are referencable by name within the enum body
+        this.pushScope();
+        for (const member of node.members) {
+          if (member.id.type === "Identifier") {
+            this.declareIdentifier(
+              member.id.name,
+              new ScopeTrackerIdentifier(member.id, this.scopeIndexKey),
+            );
+          }
         }
         break;
 
@@ -277,6 +354,9 @@ export class ScopeTracker {
       case "ArrowFunctionExpression":
       case "StaticBlock":
       case "TSModuleBlock":
+      case "TSEnumBody":
+      case "TSInterfaceDeclaration":
+      case "TSTypeAliasDeclaration":
       case "ClassExpression":
       case "ForStatement":
       case "ForOfStatement":
@@ -290,41 +370,44 @@ export class ScopeTracker {
     }
   };
 
-  /**
-   * Check if an identifier is declared in the current scope or any parent scope.
-   * @param name the identifier name to check
-   */
-  isDeclared(name: string) {
+  protected getDeclarationIn(
+    scopes: Map<string, Map<string, ScopeTrackerNode>>,
+    name: string,
+  ): ScopeTrackerNode | null {
     if (!this.scopeIndexKey) {
-      return this.scopes.get("")?.has(name) || false;
+      return scopes.get("")?.get(name) ?? null;
     }
 
     const indices = this.scopeIndexKey.split("-").map(Number);
     for (let i = indices.length; i >= 0; i--) {
-      if (this.scopes.get(indices.slice(0, i).join("-"))?.has(name)) {
-        return true;
-      }
-    }
-    return false;
-  }
-
-  /**
-   * Get the declaration node for a given identifier name.
-   * @param name the identifier name to look up
-   */
-  getDeclaration(name: string): ScopeTrackerNode | null {
-    if (!this.scopeIndexKey) {
-      return this.scopes.get("")?.get(name) ?? null;
-    }
-
-    const indices = this.scopeIndexKey.split("-").map(Number);
-    for (let i = indices.length; i >= 0; i--) {
-      const node = this.scopes.get(indices.slice(0, i).join("-"))?.get(name);
+      const node = scopes.get(indices.slice(0, i).join("-"))?.get(name);
       if (node) {
         return node;
       }
     }
     return null;
+  }
+
+  /**
+   * Check if an identifier is declared in the current scope or any parent scope.
+   * @param name the identifier name to check
+   * @param options which namespace to check — the value namespace (default), the type namespace, or both
+   */
+  isDeclared(name: string, options?: ScopeTrackerQueryOptions) {
+    return this.getDeclaration(name, options) !== null;
+  }
+
+  /**
+   * Get the declaration node for a given identifier name.
+   * @param name the identifier name to look up
+   * @param options which namespace to check — the value namespace (default), the type namespace, or both
+   */
+  getDeclaration(name: string, options?: ScopeTrackerQueryOptions): ScopeTrackerNode | null {
+    const mode = options?.mode ?? "value";
+    return (
+      (mode !== "type" ? this.getDeclarationIn(this.scopes, name) : null) ??
+      (mode !== "value" ? this.getDeclarationIn(this.typeScopes, name) : null)
+    );
   }
 
   /**
@@ -377,6 +460,9 @@ function getPatternIdentifiers(pattern: Node) {
       case "RestElement":
         collectIdentifiers(pattern.argument);
         break;
+      case "TSParameterProperty":
+        collectIdentifiers(pattern.parameter);
+        break;
       case "ArrayPattern":
         for (const element of pattern.elements) {
           if (element) {
@@ -409,6 +495,7 @@ export function isBindingIdentifier(node: Node, parent: Node | null) {
     case "FunctionDeclaration":
     case "FunctionExpression":
     case "ArrowFunctionExpression":
+    case "TSDeclareFunction":
       // function name or parameters
       if (parent.type !== "ArrowFunctionExpression" && parent.id === node) {
         return true;
@@ -451,6 +538,14 @@ export function isBindingIdentifier(node: Node, parent: Node | null) {
     case "TSModuleDeclaration":
       // enum and namespace names
       return parent.id === node;
+
+    case "TSImportEqualsDeclaration":
+      // import alias name (`import A = require('...')`)
+      return parent.id === node;
+
+    case "TSParameterProperty":
+      // constructor parameter properties (`constructor(private foo) {}`)
+      return getPatternIdentifiers(parent.parameter).includes(node);
   }
 
   return false;
@@ -468,12 +563,21 @@ export function isBindingIdentifier(node: Node, parent: Node | null) {
  * on the parent `ExportNamedDeclaration`.
  * Skip re-export declarations during the walk to avoid the false positives.
  */
-export function isReferenceIdentifier(node: Node, parent: Node | null) {
+export function isReferenceIdentifier(
+  node: Node,
+  parent: Node | null,
+  options?: IsReferenceIdentifierOptions,
+) {
   if (!parent) {
     return false;
   }
 
+  const mode = options?.mode ?? "value";
+
   if (node.type === "JSXIdentifier") {
+    if (mode === "type") {
+      return false;
+    }
     switch (parent.type) {
       case "JSXOpeningElement":
       case "JSXClosingElement":
@@ -495,20 +599,21 @@ export function isReferenceIdentifier(node: Node, parent: Node | null) {
   switch (parent.type) {
     case "MemberExpression":
       // the object and computed properties (`foo[bar]`), but not `foo.bar`
-      return parent.object === node || parent.computed;
+      return mode !== "type" && (parent.object === node || parent.computed);
 
     case "Property":
       // property values, shorthands and computed keys, but not `{ foo: 1 }`
-      return parent.value === node || parent.computed;
+      return mode !== "type" && (parent.value === node || parent.computed);
 
     case "MethodDefinition":
     case "PropertyDefinition":
+    case "AccessorProperty":
       // computed class member keys, but not `class { foo() {} }`
-      return parent.value === node || parent.computed;
+      return mode !== "type" && (parent.value === node || parent.computed);
 
     case "ExportSpecifier":
       // the local name of an export, but not the exported name of `export { foo as bar }`
-      return parent.local === node;
+      return mode !== "type" && parent.local === node;
 
     case "ExportAllDeclaration":
       // the exported name of `export * as foo from '...'`
@@ -534,11 +639,23 @@ export function isReferenceIdentifier(node: Node, parent: Node | null) {
 
     case "TSEnumMember":
       // enum member names, but not their initializers (`enum E { A = B }`)
-      return parent.id !== node;
+      return mode !== "type" && parent.id !== node;
 
-    // type-only positions
+    // references in TypeScript's type namespace
     case "TSTypeReference":
+      // type annotations (`const x: Foo`)
+      return mode !== "value";
+
     case "TSQualifiedName":
+      // the root of a qualified type name (`NS.Inner`)
+      return mode !== "value" && parent.left === node;
+
+    case "TSClassImplements":
+    case "TSInterfaceHeritage":
+      // heritage clauses (`implements Foo`, `extends Bar`)
+      return mode !== "value" && parent.expression === node;
+
+    // type-only positions that are never references
     case "TSTypeParameter":
     case "TSInterfaceDeclaration":
     case "TSTypeAliasDeclaration":
@@ -548,7 +665,19 @@ export function isReferenceIdentifier(node: Node, parent: Node | null) {
       return false;
   }
 
-  return true;
+  return mode !== "type";
+}
+
+export interface IsReferenceIdentifierOptions {
+  /**
+   * Which references to report:
+   * - `'value'`: references to runtime values, e.g. `foo()` or `typeof foo` in a type annotation
+   * - `'type'`: references in type-only positions, e.g. `const x: Foo` or `implements Foo`,
+   * which reference bindings in TypeScript's type namespace rather than runtime values
+   * - `'all'`: both
+   * @default 'value'
+   */
+  mode?: "value" | "type" | "all";
 }
 
 export function getUndeclaredIdentifiersInFunction(node: Function | ArrowFunctionExpression) {
@@ -750,4 +879,16 @@ export interface ScopeTrackerOptions {
    * @default false
    */
   preserveExitedScopes?: boolean;
+}
+
+export interface ScopeTrackerQueryOptions {
+  /**
+   * Which namespace to check:
+   * - `'value'`: bindings of runtime values (default)
+   * - `'type'`: bindings in TypeScript's type namespace (interfaces, type aliases, type parameters);
+   * declarations available in both namespaces (classes, enums, namespaces, imports) are included in either
+   * - `'all'`: both
+   * @default 'value'
+   */
+  mode?: "value" | "type" | "all";
 }

--- a/src/scope-tracker.ts
+++ b/src/scope-tracker.ts
@@ -496,7 +496,9 @@ export function isBindingIdentifier(node: Node, parent: Node | null) {
     case "FunctionExpression":
     case "ArrowFunctionExpression":
     case "TSDeclareFunction":
+    case "TSEmptyBodyFunctionExpression":
       // function name or parameters
+      // (`TSEmptyBodyFunctionExpression` covers abstract methods, `declare class` methods and overload signatures)
       if (parent.type !== "ArrowFunctionExpression" && parent.id === node) {
         return true;
       }
@@ -608,6 +610,9 @@ export function isReferenceIdentifier(
     case "MethodDefinition":
     case "PropertyDefinition":
     case "AccessorProperty":
+    case "TSAbstractMethodDefinition":
+    case "TSAbstractPropertyDefinition":
+    case "TSAbstractAccessorProperty":
       // computed class member keys, but not `class { foo() {} }`
       return mode !== "type" && (parent.value === node || parent.computed);
 
@@ -662,6 +667,13 @@ export function isReferenceIdentifier(
     case "TSPropertySignature":
     case "TSMethodSignature":
     case "TSIndexSignature":
+      return false;
+
+    // parameter names of function types and signatures (`type F = (foo: string) => void`)
+    case "TSFunctionType":
+    case "TSConstructorType":
+    case "TSCallSignatureDeclaration":
+    case "TSConstructSignatureDeclaration":
       return false;
   }
 

--- a/src/scope-tracker.ts
+++ b/src/scope-tracker.ts
@@ -5,6 +5,7 @@ import type {
   IdentifierReference,
   ImportDeclaration,
   ImportDeclarationSpecifier,
+  JSXIdentifier,
   Node,
   VariableDeclaration,
 } from "@oxc-project/types";
@@ -383,6 +384,9 @@ function getPatternIdentifiers(pattern: Node) {
   return identifiers;
 }
 
+/**
+ * Check if an identifier is in a binding position, where it declares a new variable.
+ */
 export function isBindingIdentifier(node: Node, parent: Node | null) {
   if (!parent || node.type !== "Identifier") {
     return false;
@@ -411,14 +415,6 @@ export function isBindingIdentifier(node: Node, parent: Node | null) {
       // class name
       return parent.id === node;
 
-    case "MethodDefinition":
-      // class method name, except computed ones
-      return parent.key === node && !parent.computed;
-
-    case "PropertyDefinition":
-      // class property name, except computed ones
-      return parent.key === node && !parent.computed;
-
     case "VariableDeclarator":
       // variable name
       return getPatternIdentifiers(parent.id).includes(node);
@@ -430,16 +426,98 @@ export function isBindingIdentifier(node: Node, parent: Node | null) {
       }
       return getPatternIdentifiers(parent.param).includes(node);
 
-    case "Property":
-      // property key if not used as a shorthand or a computed key
-      return parent.key === node && parent.value !== node && !parent.computed;
+    case "ImportSpecifier":
+      // the local name of an import
+      return parent.local === node;
 
-    case "MemberExpression":
-      // member expression properties, except computed ones (`foo[bar]`)
-      return parent.property === node && !parent.computed;
+    case "ImportDefaultSpecifier":
+    case "ImportNamespaceSpecifier":
+      return true;
   }
 
   return false;
+}
+
+/**
+ * Check if an identifier is a reference.
+ *
+ * Note that this function returns `true` for the local name of a plain export
+ * (`export { foo }`), where it is a genuine reference to a local variable,
+ * but also for the local name of a re-export (`export { foo } from '...'`),
+ * where it refers to the other module's exports instead.
+ *
+ * The two are indistinguishable from the specifier alone, as the `source` lives
+ * on the parent `ExportNamedDeclaration`.
+ * Skip re-export declarations during the walk to avoid the false positives.
+ */
+export function isReferenceIdentifier(node: Node, parent: Node | null) {
+  if (!parent) {
+    return false;
+  }
+
+  if (node.type === "JSXIdentifier") {
+    switch (parent.type) {
+      case "JSXOpeningElement":
+      case "JSXClosingElement":
+        // lowercase element names refer to intrinsic elements, not variables
+        return parent.name === node && !/^[a-z]/.test(node.name);
+      case "JSXMemberExpression":
+        return parent.object === node;
+      case "JSXAttribute":
+      case "JSXNamespacedName":
+        return false;
+    }
+    return false;
+  }
+
+  if (node.type !== "Identifier" || isBindingIdentifier(node, parent)) {
+    return false;
+  }
+
+  switch (parent.type) {
+    case "MemberExpression":
+      // the object and computed properties (`foo[bar]`), but not `foo.bar`
+      return parent.object === node || parent.computed;
+
+    case "Property":
+      // property values, shorthands and computed keys, but not `{ foo: 1 }`
+      return parent.value === node || parent.computed;
+
+    case "MethodDefinition":
+    case "PropertyDefinition":
+      // computed class member keys, but not `class { foo() {} }`
+      return parent.value === node || parent.computed;
+
+    case "ExportSpecifier":
+      // the local name of an export, but not the exported name of `export { foo as bar }`
+      return parent.local === node;
+
+    case "ExportAllDeclaration":
+      // the exported name of `export * as foo from '...'`
+      return false;
+
+    case "ImportSpecifier":
+      // the imported name of `import { foo as bar }`
+      return false;
+
+    case "LabeledStatement":
+    case "BreakStatement":
+    case "ContinueStatement":
+      // statement labels
+      return false;
+
+    // type-only positions
+    case "TSTypeReference":
+    case "TSQualifiedName":
+    case "TSTypeParameter":
+    case "TSInterfaceDeclaration":
+    case "TSTypeAliasDeclaration":
+    case "TSPropertySignature":
+    case "TSMethodSignature":
+      return false;
+  }
+
+  return true;
 }
 
 export function getUndeclaredIdentifiersInFunction(node: Function | ArrowFunctionExpression) {
@@ -449,10 +527,10 @@ export function getUndeclaredIdentifiersInFunction(node: Function | ArrowFunctio
   const undeclaredIdentifiers = new Set<string>();
 
   function isIdentifierUndeclared(
-    node: Omit<IdentifierReference, "typeAnnotation">,
+    node: Omit<IdentifierReference, "typeAnnotation"> | JSXIdentifier,
     parent: Node | null,
   ) {
-    return !isBindingIdentifier(node, parent) && !scopeTracker.isDeclared(node.name);
+    return isReferenceIdentifier(node, parent) && !scopeTracker.isDeclared(node.name);
   }
 
   // first pass to collect all declarations and hoist them
@@ -465,7 +543,10 @@ export function getUndeclaredIdentifiersInFunction(node: Function | ArrowFunctio
   walk(node, {
     scopeTracker,
     enter(node, parent) {
-      if (node.type === "Identifier" && isIdentifierUndeclared(node, parent)) {
+      if (
+        (node.type === "Identifier" || node.type === "JSXIdentifier") &&
+        isIdentifierUndeclared(node, parent)
+      ) {
         undeclaredIdentifiers.add(node.name);
       }
     },

--- a/src/scope-tracker.ts
+++ b/src/scope-tracker.ts
@@ -154,6 +154,7 @@ export class ScopeTracker {
       case "Program":
       case "BlockStatement":
       case "StaticBlock":
+      case "TSModuleBlock":
         this.pushScope();
         break;
 
@@ -226,6 +227,17 @@ export class ScopeTracker {
         }
         break;
 
+      case "TSEnumDeclaration":
+      case "TSModuleDeclaration":
+        // enums and namespaces declare a value binding for their name
+        if (node.id.type === "Identifier" && node.id.name) {
+          this.declareIdentifier(
+            node.id.name,
+            new ScopeTrackerIdentifier(node.id, this.scopeIndexKey),
+          );
+        }
+        break;
+
       case "CatchClause":
         this.pushScope();
         if (node.param) {
@@ -264,6 +276,7 @@ export class ScopeTracker {
       case "FunctionDeclaration":
       case "ArrowFunctionExpression":
       case "StaticBlock":
+      case "TSModuleBlock":
       case "ClassExpression":
       case "ForStatement":
       case "ForOfStatement":
@@ -433,6 +446,11 @@ export function isBindingIdentifier(node: Node, parent: Node | null) {
     case "ImportDefaultSpecifier":
     case "ImportNamespaceSpecifier":
       return true;
+
+    case "TSEnumDeclaration":
+    case "TSModuleDeclaration":
+      // enum and namespace names
+      return parent.id === node;
   }
 
   return false;
@@ -506,6 +524,18 @@ export function isReferenceIdentifier(node: Node, parent: Node | null) {
       // statement labels
       return false;
 
+    case "MetaProperty":
+      // `import.meta` and `new.target`
+      return false;
+
+    case "ImportAttribute":
+      // attribute keys (`with { type: 'json' }`)
+      return false;
+
+    case "TSEnumMember":
+      // enum member names, but not their initializers (`enum E { A = B }`)
+      return parent.id !== node;
+
     // type-only positions
     case "TSTypeReference":
     case "TSQualifiedName":
@@ -514,6 +544,7 @@ export function isReferenceIdentifier(node: Node, parent: Node | null) {
     case "TSTypeAliasDeclaration":
     case "TSPropertySignature":
     case "TSMethodSignature":
+    case "TSIndexSignature":
       return false;
   }
 

--- a/src/scope-tracker.ts
+++ b/src/scope-tracker.ts
@@ -486,7 +486,7 @@ function getPatternIdentifiers(pattern: Node) {
 /**
  * Check if an identifier is in a binding position, where it declares a new variable.
  */
-export function isBindingIdentifier(node: Node, parent: Node | null) {
+export function isOnlyBindingIdentifier(node: Node, parent: Node | null) {
   if (!parent || node.type !== "Identifier") {
     return false;
   }
@@ -553,6 +553,44 @@ export function isBindingIdentifier(node: Node, parent: Node | null) {
   return false;
 }
 
+// @todo: remove in v2
+/**
+ * @deprecated
+ * Despite its name, this function does not check for binding positions only.
+ * It will adopt the strict binding-position behavior of {@link isOnlyBindingIdentifier}
+ * in the next major version. Migrate based on what you need:
+ * - `!isReferenceIdentifier(node, parent)` if you were filtering out variable references
+ *   (the common case)
+ * - `isOnlyBindingIdentifier(node, parent)` if you need actual binding positions
+ */
+export function isBindingIdentifier(node: Node, parent: Node | null) {
+  if (!parent || node.type !== "Identifier") {
+    return false;
+  }
+
+  if (isOnlyBindingIdentifier(node, parent)) {
+    return true;
+  }
+
+  // non-binding, non-reference positions this function historically reported as bindings
+  switch (parent.type) {
+    case "MethodDefinition":
+    case "PropertyDefinition":
+      // class member names
+      return parent.key === node;
+
+    case "Property":
+      // property key if not used as a shorthand
+      return parent.key === node && parent.value !== node;
+
+    case "MemberExpression":
+      // member expression properties
+      return parent.property === node;
+  }
+
+  return false;
+}
+
 /**
  * Check if an identifier is a reference.
  *
@@ -594,7 +632,7 @@ export function isReferenceIdentifier(
     return false;
   }
 
-  if (node.type !== "Identifier" || isBindingIdentifier(node, parent)) {
+  if (node.type !== "Identifier" || isOnlyBindingIdentifier(node, parent)) {
     return false;
   }
 

--- a/src/scope-tracker.ts
+++ b/src/scope-tracker.ts
@@ -412,12 +412,12 @@ export function isBindingIdentifier(node: Node, parent: Node | null) {
       return parent.id === node;
 
     case "MethodDefinition":
-      // class method name
-      return parent.key === node;
+      // class method name, except computed ones
+      return parent.key === node && !parent.computed;
 
     case "PropertyDefinition":
-      // class property name
-      return parent.key === node;
+      // class property name, except computed ones
+      return parent.key === node && !parent.computed;
 
     case "VariableDeclarator":
       // variable name
@@ -431,12 +431,12 @@ export function isBindingIdentifier(node: Node, parent: Node | null) {
       return getPatternIdentifiers(parent.param).includes(node);
 
     case "Property":
-      // property key if not used as a shorthand
-      return parent.key === node && parent.value !== node;
+      // property key if not used as a shorthand or a computed key
+      return parent.key === node && parent.value !== node && !parent.computed;
 
     case "MemberExpression":
-      // member expression properties
-      return parent.property === node;
+      // member expression properties, except computed ones (`foo[bar]`)
+      return parent.property === node && !parent.computed;
   }
 
   return false;

--- a/src/scope-tracker.ts
+++ b/src/scope-tracker.ts
@@ -225,6 +225,10 @@ export class ScopeTracker {
             { value: true, type: true },
           );
         }
+        // a scope is pushed for generic classes so that their type parameters do not leak out
+        if (node.typeParameters) {
+          this.pushScope();
+        }
         break;
 
       case "ClassExpression":
@@ -268,13 +272,15 @@ export class ScopeTracker {
         break;
 
       case "TSDeclareFunction":
-        // `declare function` and function overload signatures declare a value binding
+        // `declare function` and function overload signatures declare a value binding;
+        // a scope is pushed so that their type parameters do not leak out
         if (node.id?.name) {
           this.declareIdentifier(
             node.id.name,
             new ScopeTrackerIdentifier(node.id, this.scopeIndexKey),
           );
         }
+        this.pushScope();
         break;
 
       case "TSInterfaceDeclaration":
@@ -300,6 +306,17 @@ export class ScopeTracker {
             { type: true },
           );
         }
+        break;
+
+      case "TSMappedType":
+        // the key of a mapped type declares a type parameter scoped to the mapped type
+        // (`{ [K in keyof T]: K }`)
+        this.pushScope();
+        this.declareIdentifier(
+          node.key.name,
+          new ScopeTrackerIdentifier(node.key, this.scopeIndexKey),
+          { type: true },
+        );
         break;
 
       case "TSEnumBody":
@@ -357,6 +374,8 @@ export class ScopeTracker {
       case "TSEnumBody":
       case "TSInterfaceDeclaration":
       case "TSTypeAliasDeclaration":
+      case "TSDeclareFunction":
+      case "TSMappedType":
       case "ClassExpression":
       case "ForStatement":
       case "ForOfStatement":
@@ -366,6 +385,11 @@ export class ScopeTracker {
       case "FunctionExpression":
         this.popScope();
         this.popScope();
+        break;
+      case "ClassDeclaration":
+        if (node.typeParameters) {
+          this.popScope();
+        }
         break;
     }
   };
@@ -485,6 +509,11 @@ function getPatternIdentifiers(pattern: Node) {
 
 /**
  * Check if an identifier is in a binding position, where it declares a new variable.
+ *
+ * Note that identifiers nested in destructuring patterns (`const { a, b = c } = obj`)
+ * cannot be resolved from the direct parent alone; this function returns `false` for them
+ * and {@link isReferenceIdentifier} reports them as references.
+ * Pair these functions with a {@link ScopeTracker} to resolve such identifiers correctly.
  */
 export function isOnlyBindingIdentifier(node: Node, parent: Node | null) {
   if (!parent || node.type !== "Identifier") {
@@ -602,6 +631,10 @@ export function isBindingIdentifier(node: Node, parent: Node | null) {
  * The two are indistinguishable from the specifier alone, as the `source` lives
  * on the parent `ExportNamedDeclaration`.
  * Skip re-export declarations during the walk to avoid the false positives.
+ *
+ * Identifiers nested in destructuring patterns (`const { a, b = c } = obj`) are also
+ * indistinguishable from references based on the direct parent alone and are reported
+ * as references. Pair this function with a {@link ScopeTracker} to resolve them correctly.
  */
 export function isReferenceIdentifier(
   node: Node,
@@ -683,6 +716,10 @@ export function isReferenceIdentifier(
     case "TSEnumMember":
       // enum member names, but not their initializers (`enum E { A = B }`)
       return mode !== "type" && parent.id !== node;
+
+    case "TSMappedType":
+      // the key of a mapped type declares a type parameter (`{ [K in keyof T]: K }`)
+      return false;
 
     // references in TypeScript's type namespace
     case "TSTypeReference":

--- a/test/scope-tracker.test.ts
+++ b/test/scope-tracker.test.ts
@@ -1572,6 +1572,40 @@ describe("reference identifiers", () => {
     ).toEqual([]);
   });
 
+  it("should declare mapped type keys and not report them as references", () => {
+    const code = `
+    type X = { [K in keyof Y]: K }
+    `;
+
+    expect(getUnmatchedIdentifiers(code)).toEqual([]);
+    expect(getUnmatchedIdentifiers(code, filename, { mode: "type" })).toEqual(["Y"]);
+  });
+
+  it("should not leak type parameters out of their declarations", () => {
+    const code = `
+    class Foo<T> {
+      method(value: T): T { return value }
+    }
+    declare function df<U>(x: U): U
+    interface Bar<V> { prop: V }
+    const marker = 1
+    `;
+
+    expect(getUnmatchedIdentifiers(code, filename, { mode: "all" })).toEqual([]);
+
+    const scopeTracker = new ScopeTracker();
+    parseAndWalk(code, filename, {
+      scopeTracker,
+      enter(node) {
+        if (node.type === "VariableDeclaration") {
+          for (const name of ["T", "U", "V"]) {
+            expect(scopeTracker.isDeclared(name, { mode: "all" })).toBe(false);
+          }
+        }
+      },
+    });
+  });
+
   it("should detect references in JSX member expressions", () => {
     expect(getUnmatchedIdentifiers(`const el = <Foo.Bar.baz />`, "test.tsx")).toEqual(["Foo"]);
     expect(getUnmatchedIdentifiers(`const el = <foo.bar />`, "test.tsx")).toEqual(["foo"]);

--- a/test/scope-tracker.test.ts
+++ b/test/scope-tracker.test.ts
@@ -1238,6 +1238,50 @@ describe("reference identifiers", () => {
 
     expect(getUnmatchedIdentifiers(code, "test.tsx")).toEqual(["Foo", "bar", "baz"]);
   });
+
+  it("should not report meta properties as references", () => {
+    const code = `
+    const url = import.meta.url
+    function f() { return new.target }
+    `;
+
+    expect(getUnmatchedIdentifiers(code)).toEqual([]);
+  });
+
+  it("should not report import attribute keys as references", () => {
+    const code = `
+    import data from './data.json' with { type: 'json' }
+    data
+    `;
+
+    expect(getUnmatchedIdentifiers(code)).toEqual([]);
+  });
+
+  it("should declare enums and not report their members as references", () => {
+    const code = `
+    enum E { A, B }
+    const x = E.A
+    `;
+
+    expect(getUnmatchedIdentifiers(code)).toEqual([]);
+  });
+
+  it("should declare namespaces and not report their names as references", () => {
+    const code = `
+    namespace NS { export const a = 1 }
+    NS.a
+    `;
+
+    expect(getUnmatchedIdentifiers(code)).toEqual([]);
+  });
+
+  it("should not report index signature parameters as references", () => {
+    const code = `
+    interface I { [key: string]: number }
+    `;
+
+    expect(getUnmatchedIdentifiers(code)).toEqual([]);
+  });
 });
 
 export class TestScopeTracker extends ScopeTracker {

--- a/test/scope-tracker.test.ts
+++ b/test/scope-tracker.test.ts
@@ -1,6 +1,12 @@
 import type { Node } from "oxc-parser";
 import { assert, describe, expect, it } from "vite-plus/test";
-import { getUndeclaredIdentifiersInFunction, parseAndWalk, ScopeTracker, walk } from "../src";
+import {
+  getUndeclaredIdentifiersInFunction,
+  isReferenceIdentifier,
+  parseAndWalk,
+  ScopeTracker,
+  walk,
+} from "../src";
 
 function getNodeString(node: Node) {
   const parts: string[] = [node.type];
@@ -460,6 +466,68 @@ describe("scope tracker", () => {
     expect(scopeTracker.getScopes().get("")?.size).toBe(3);
   });
 
+  it("should resolve identifiers used as switch case labels", () => {
+    const code = `
+    import { foo } from './foo'
+    const bar = 1
+    function baz() {}
+    class Qux {}
+
+    switch (input) {
+      case foo:
+        break
+      case bar:
+        break
+      case baz:
+        break
+      case Qux:
+        break
+      case nope:
+        break
+    }
+    `;
+
+    const scopeTracker = new TestScopeTracker({
+      preserveExitedScopes: true,
+    });
+
+    let processedCases = 0;
+
+    parseAndWalk(code, filename, {
+      scopeTracker,
+      enter: (node) => {
+        if (node.type !== "SwitchCase" || node.test?.type !== "Identifier") {
+          return;
+        }
+
+        const declaration = scopeTracker.getDeclaration(node.test.name);
+        switch (node.test.name) {
+          case "foo":
+            expect(declaration?.type).toEqual("Import");
+            break;
+          case "bar":
+            expect(declaration?.type).toEqual("Variable");
+            break;
+          case "baz":
+            expect(declaration?.type).toEqual("Function");
+            break;
+          case "Qux":
+            expect(declaration?.type).toEqual("Identifier");
+            break;
+          case "nope":
+            expect(declaration).toBeNull();
+            break;
+          default:
+            assert.fail(`Unexpected switch case label: ${node.test.name}`);
+        }
+
+        processedCases++;
+      },
+    });
+
+    expect(processedCases).toBe(5);
+  });
+
   it("should handle classes", () => {
     const code = `
     // ""
@@ -873,6 +941,302 @@ describe("parsing", () => {
     expect(e.isUnderScope(b.scope)).toBe(false);
     expect(b.isUnderScope(d.scope)).toBe(false);
     expect(c.isUnderScope(e.scope)).toBe(false);
+  });
+
+  it("should treat identifiers in switch case tests as references", () => {
+    const code = `
+    function handle(input) {
+      const foo = 1
+
+      switch (input) {
+        case foo:
+          return 1
+        case bar:
+          return 2
+        default:
+          return 0
+      }
+    }
+    `;
+
+    let processedFunctions = 0;
+
+    parseAndWalk(code, filename, {
+      enter: (node) => {
+        if (node.type !== "FunctionDeclaration") {
+          return;
+        }
+
+        // `input` and `foo` are declared within the function,
+        // while `bar` is a reference to an identifier outside of it
+        expect(getUndeclaredIdentifiersInFunction(node)).toEqual(["bar"]);
+
+        processedFunctions++;
+      },
+    });
+
+    expect(processedFunctions).toBe(1);
+  });
+});
+
+describe("reference identifiers", () => {
+  function getUnmatchedIdentifiers(code: string, sourceFilename = filename): string[] {
+    const scopeTracker = new ScopeTracker({ preserveExitedScopes: true });
+
+    // first pass to collect all declarations and hoist them
+    parseAndWalk(code, sourceFilename, { scopeTracker });
+    scopeTracker.freeze();
+
+    const unmatched = new Set<string>();
+    parseAndWalk(code, sourceFilename, {
+      scopeTracker,
+      enter(node, parent) {
+        // re-export specifiers refer to the other module's exports
+        if (node.type === "ExportNamedDeclaration" && node.source) {
+          this.skip();
+          return;
+        }
+
+        if (
+          (node.type === "Identifier" || node.type === "JSXIdentifier") &&
+          isReferenceIdentifier(node, parent) &&
+          !scopeTracker.isDeclared(node.name)
+        ) {
+          unmatched.add(node.name);
+        }
+      },
+    });
+
+    return [...unmatched].sort();
+  }
+
+  it("should detect references in statements", () => {
+    const code = `
+    switch (input) {
+      case ref1:
+        break
+    }
+
+    function fn1() {
+      return ref2
+    }
+    function fn2() {
+      throw ref3
+    }
+    function fn3(p1 = ref4) {
+      return p1
+    }
+
+    for (const i of ref5) {}
+    for (const i in ref6) {}
+
+    export default ref7
+
+    const [d1 = ref8] = []
+    const { d2 = ref9 } = {}
+    `;
+
+    expect(getUnmatchedIdentifiers(code)).toEqual([
+      "input",
+      "ref1",
+      "ref2",
+      "ref3",
+      "ref4",
+      "ref5",
+      "ref6",
+      "ref7",
+      "ref8",
+      "ref9",
+    ]);
+  });
+
+  it("should not report identifiers declared via patterns and params", () => {
+    const code = `
+    const [a1 = 1] = []
+    const { a2 = 1, ...a3 } = {}
+    try {} catch (e1) { e1() }
+    function fn1({ p1 }, [p2], p3 = 1, ...p4) {
+      p1(); p2(); p3(); p4()
+    }
+    const fn2 = ({ p5 }) => p5()
+    a1(); a2(); a3()
+    `;
+
+    expect(getUnmatchedIdentifiers(code)).toEqual([]);
+  });
+
+  it("should not leak params and catch bindings to the enclosing scope", () => {
+    const code = `
+    const fn1 = ({ p1 }) => p1()
+    function fn2(p2) { p2() }
+    try {} catch ({ e1 }) { e1() }
+    p1(); p2(); e1()
+    `;
+
+    expect(getUnmatchedIdentifiers(code)).toEqual(["e1", "p1", "p2"]);
+  });
+
+  it("should resolve references to imports", () => {
+    const code = `
+    import { Bar } from 'foobar'
+    function foo(mode) {
+      switch (mode) {
+        case Foo:
+          return Bar
+      }
+    }
+    `;
+
+    expect(getUnmatchedIdentifiers(code)).toEqual(["Foo"]);
+  });
+
+  it("should detect references in computed member expressions", () => {
+    const code = `
+    obj[ref1]
+    `;
+
+    expect(getUnmatchedIdentifiers(code)).toEqual(["obj", "ref1"]);
+  });
+
+  it("should detect references in computed keys", () => {
+    const code = `
+    const obj = { [ref1]: 1 }
+    class C1 {
+      [ref2] = ref3;
+      [ref4]() {}
+    }
+    `;
+
+    expect(getUnmatchedIdentifiers(code)).toEqual(["ref1", "ref2", "ref3", "ref4"]);
+  });
+
+  it("should not report re-export specifiers as references", () => {
+    const code = `
+    export { ref1 } from './one'
+    export { ref2 as ref3 } from './two'
+    export * as ref4 from './three'
+    `;
+
+    expect(getUnmatchedIdentifiers(code)).toEqual([]);
+  });
+
+  it("should detect renamed imports", () => {
+    const code = `
+    import { a as b } from 'x'
+    b()
+    `;
+
+    expect(getUnmatchedIdentifiers(code)).toEqual([]);
+  });
+
+  it("should not report statement labels as references", () => {
+    const code = `
+    outer: for (const i of list) {
+      if (i) break outer
+      continue outer
+    }
+    `;
+
+    expect(getUnmatchedIdentifiers(code)).toEqual(["list"]);
+  });
+
+  it("should not report type-only identifiers as references", () => {
+    const code = `
+    const x: SomeType = load<OtherType>()
+    interface Foo { bar: Baz }
+    `;
+
+    expect(getUnmatchedIdentifiers(code)).toEqual(["load"]);
+  });
+
+  it("should detect references in expression positions", () => {
+    const code = `
+    const obj = { foo }
+    class A extends Base {}
+    typeof ref1
+    const sum = ref2 + ref3
+    const pick = cond ? ref4 : ref5
+    const arr = [...ref6]
+    const fn = async () => await ref7
+    const tpl = tag\`\${ref8}\`
+    const inst = new Ctor()
+    `;
+
+    expect(getUnmatchedIdentifiers(code)).toEqual([
+      "Base",
+      "Ctor",
+      "cond",
+      "foo",
+      "ref1",
+      "ref2",
+      "ref3",
+      "ref4",
+      "ref5",
+      "ref6",
+      "ref7",
+      "ref8",
+      "tag",
+    ]);
+  });
+
+  it("should detect references in assignment targets", () => {
+    const code = `
+    ref1 = 1
+    ref2++
+    ;({ a: ref3 } = obj)
+    ;[ref4] = arr
+    `;
+
+    expect(getUnmatchedIdentifiers(code)).toEqual(["arr", "obj", "ref1", "ref2", "ref3", "ref4"]);
+  });
+
+  it("should not report non-computed keys and members as references", () => {
+    const code = `
+    obj.prop
+    const x = { key: 1 }
+    class C {
+      method() {}
+      get accessor() { return 1 }
+    }
+    `;
+
+    expect(getUnmatchedIdentifiers(code)).toEqual(["obj"]);
+  });
+
+  it("should report export specifiers without a source as references", () => {
+    const code = `
+    const foo = 1
+    export { foo, bar }
+    `;
+
+    expect(getUnmatchedIdentifiers(code)).toEqual(["bar"]);
+  });
+
+  it("should detect references in computed pattern keys", () => {
+    const code = `
+    const { [key]: value } = obj
+    `;
+
+    expect(getUnmatchedIdentifiers(code)).toEqual(["key", "obj"]);
+  });
+
+  it("should resolve references to hoisted declarations", () => {
+    const code = `
+    foo()
+    bar
+    function foo() {}
+    var bar = 1
+    `;
+
+    expect(getUnmatchedIdentifiers(code)).toEqual([]);
+  });
+
+  it("should detect references in JSX", () => {
+    const code = `
+    const el = <Foo prop={bar}>{baz}</Foo>
+    `;
+
+    expect(getUnmatchedIdentifiers(code, "test.tsx")).toEqual(["Foo", "bar", "baz"]);
   });
 });
 

--- a/test/scope-tracker.test.ts
+++ b/test/scope-tracker.test.ts
@@ -1,5 +1,6 @@
 import type { Node } from "oxc-parser";
 import { assert, describe, expect, it } from "vite-plus/test";
+import type { IsReferenceIdentifierOptions, ScopeTrackerQueryOptions } from "../src";
 import {
   getUndeclaredIdentifiersInFunction,
   isReferenceIdentifier,
@@ -600,6 +601,36 @@ describe("scope tracker", () => {
     expect(scopeTracker.isDeclaredInScope("e", "2-0-0")).toBe(true);
   });
 
+  it("should track type declarations in the type namespace", () => {
+    const code = `
+    interface Foo {}
+    type Alias = 1
+    class Klass {}
+    const value = 1
+    `;
+
+    const scopeTracker = new TestScopeTracker({
+      preserveExitedScopes: true,
+    });
+
+    parseAndWalk(code, filename, {
+      scopeTracker,
+    });
+
+    expect(scopeTracker.isDeclaredInScope("Foo", "")).toBe(false);
+    expect(scopeTracker.isDeclaredInScope("Foo", "", { mode: "type" })).toBe(true);
+
+    expect(scopeTracker.isDeclaredInScope("Alias", "")).toBe(false);
+    expect(scopeTracker.isDeclaredInScope("Alias", "", { mode: "type" })).toBe(true);
+
+    expect(scopeTracker.isDeclaredInScope("Klass", "")).toBe(true);
+    expect(scopeTracker.isDeclaredInScope("Klass", "", { mode: "type" })).toBe(true);
+
+    expect(scopeTracker.isDeclaredInScope("value", "")).toBe(true);
+    expect(scopeTracker.isDeclaredInScope("value", "", { mode: "type" })).toBe(false);
+    expect(scopeTracker.isDeclaredInScope("value", "", { mode: "all" })).toBe(true);
+  });
+
   it("should freeze scopes", () => {
     let code = `
     const a = 1
@@ -980,12 +1011,21 @@ describe("parsing", () => {
 });
 
 describe("reference identifiers", () => {
-  function getUnmatchedIdentifiers(code: string, sourceFilename = filename): string[] {
+  function getUnmatchedIdentifiers(
+    code: string,
+    sourceFilename = filename,
+    options?: IsReferenceIdentifierOptions,
+  ): string[] {
     const scopeTracker = new ScopeTracker({ preserveExitedScopes: true });
 
     // first pass to collect all declarations and hoist them
     parseAndWalk(code, sourceFilename, { scopeTracker });
     scopeTracker.freeze();
+
+    const modes =
+      options?.mode === "all"
+        ? (["value", "type"] as const)
+        : ([options?.mode ?? "value"] as const);
 
     const unmatched = new Set<string>();
     parseAndWalk(code, sourceFilename, {
@@ -997,12 +1037,17 @@ describe("reference identifiers", () => {
           return;
         }
 
-        if (
-          (node.type === "Identifier" || node.type === "JSXIdentifier") &&
-          isReferenceIdentifier(node, parent) &&
-          !scopeTracker.isDeclared(node.name)
-        ) {
-          unmatched.add(node.name);
+        if (node.type !== "Identifier" && node.type !== "JSXIdentifier") {
+          return;
+        }
+
+        for (const mode of modes) {
+          if (
+            isReferenceIdentifier(node, parent, { mode }) &&
+            !scopeTracker.isDeclared(node.name, { mode })
+          ) {
+            unmatched.add(node.name);
+          }
         }
       },
     });
@@ -1282,6 +1327,119 @@ describe("reference identifiers", () => {
 
     expect(getUnmatchedIdentifiers(code)).toEqual([]);
   });
+
+  it("should declare function overloads and declare functions", () => {
+    const code = `
+    declare function foo(a: number): void
+    function bar(b: string): void
+    function bar(b) { return b }
+    foo(bar)
+    `;
+
+    expect(getUnmatchedIdentifiers(code)).toEqual([]);
+  });
+
+  it("should declare constructor parameter properties", () => {
+    const code = `
+    class C {
+      constructor(private x: number, public y: string) {
+        x; y
+      }
+    }
+    `;
+
+    expect(getUnmatchedIdentifiers(code)).toEqual([]);
+  });
+
+  it("should not report type-only heritage clauses as references", () => {
+    const code = `
+    class A implements I {}
+    interface B extends C {}
+    `;
+
+    expect(getUnmatchedIdentifiers(code)).toEqual([]);
+  });
+
+  it("should not report accessor property keys as references", () => {
+    const code = `
+    class C {
+      accessor foo = bar;
+      accessor [baz] = 1;
+    }
+    `;
+
+    expect(getUnmatchedIdentifiers(code)).toEqual(["bar", "baz"]);
+  });
+
+  it("should declare import equals bindings", () => {
+    const code = `
+    import A = require('mod')
+    A
+    `;
+
+    expect(getUnmatchedIdentifiers(code)).toEqual([]);
+  });
+
+  it("should resolve enum member references in initializers", () => {
+    expect(getUnmatchedIdentifiers(`enum E { A, B = A }`)).toEqual([]);
+    expect(getUnmatchedIdentifiers(`enum E { A }\nA`)).toEqual(["A"]);
+  });
+
+  it("should not declare the global identifier from declare global", () => {
+    const code = `
+    declare global { interface Window {} }
+    global
+    `;
+
+    expect(getUnmatchedIdentifiers(code)).toEqual(["global"]);
+  });
+
+  it("should report type-only references depending on the mode", () => {
+    const code = `
+    const x: SomeType = load<OtherType>()
+    class A implements I {}
+    interface B extends C {}
+    type T = NS.Inner
+    type Q = typeof runtimeValue
+    `;
+
+    expect(getUnmatchedIdentifiers(code)).toEqual(["load", "runtimeValue"]);
+    expect(getUnmatchedIdentifiers(code, filename, { mode: "type" })).toEqual([
+      "C",
+      "I",
+      "NS",
+      "OtherType",
+      "SomeType",
+    ]);
+    expect(getUnmatchedIdentifiers(code, filename, { mode: "all" })).toEqual([
+      "C",
+      "I",
+      "NS",
+      "OtherType",
+      "SomeType",
+      "load",
+      "runtimeValue",
+    ]);
+  });
+
+  it("should resolve type references to local type declarations", () => {
+    const code = `
+    interface Foo {}
+    type Bar<T> = T | Foo
+    class Klass {}
+    const x: Foo = new Klass()
+    const y: Unknown = 1
+    console.log(Foo)
+    `;
+
+    expect(getUnmatchedIdentifiers(code)).toEqual(["Foo", "console"]);
+    expect(getUnmatchedIdentifiers(code, filename, { mode: "type" })).toEqual(["Unknown"]);
+    expect(getUnmatchedIdentifiers(code, filename, { mode: "all" })).toEqual([
+      "Foo",
+      "Unknown",
+      "console",
+    ]);
+  });
 });
 
 export class TestScopeTracker extends ScopeTracker {
@@ -1297,18 +1455,18 @@ export class TestScopeTracker extends ScopeTracker {
     return this.scopeIndexStack;
   }
 
-  isDeclaredInScope(identifier: string, scope: string) {
+  isDeclaredInScope(identifier: string, scope: string, options?: ScopeTrackerQueryOptions) {
     const oldKey = this.scopeIndexKey;
     this.scopeIndexKey = scope;
-    const result = this.isDeclared(identifier);
+    const result = this.isDeclared(identifier, options);
     this.scopeIndexKey = oldKey;
     return result;
   }
 
-  getDeclarationFromScope(identifier: string, scope: string) {
+  getDeclarationFromScope(identifier: string, scope: string, options?: ScopeTrackerQueryOptions) {
     const oldKey = this.scopeIndexKey;
     this.scopeIndexKey = scope;
-    const result = this.getDeclaration(identifier);
+    const result = this.getDeclaration(identifier, options);
     this.scopeIndexKey = oldKey;
     return result;
   }

--- a/test/scope-tracker.test.ts
+++ b/test/scope-tracker.test.ts
@@ -3,9 +3,16 @@ import { assert, describe, expect, it } from "vite-plus/test";
 import type { IsReferenceIdentifierOptions, ScopeTrackerQueryOptions } from "../src";
 import {
   getUndeclaredIdentifiersInFunction,
+  isBindingIdentifier,
   isReferenceIdentifier,
   parseAndWalk,
   ScopeTracker,
+  ScopeTrackerCatchParam,
+  ScopeTrackerFunction,
+  ScopeTrackerFunctionParam,
+  ScopeTrackerIdentifier,
+  ScopeTrackerImport,
+  ScopeTrackerVariable,
   walk,
 } from "../src";
 
@@ -780,6 +787,79 @@ describe("scope tracker", () => {
       ]
     `);
   });
+
+  it("should report the current scope and its relation to parent scopes", () => {
+    const code = `
+    const a = 1
+    function foo() {
+      const b = 2
+    }
+    `;
+
+    const scopeTracker = new TestScopeTracker();
+    const observed: Array<[string, boolean, boolean]> = [];
+
+    parseAndWalk(code, filename, {
+      scopeTracker,
+      enter(node) {
+        if (node.type === "VariableDeclaration") {
+          observed.push([
+            scopeTracker.getCurrentScope(),
+            scopeTracker.isCurrentScopeUnder("0"),
+            scopeTracker.isCurrentScopeUnder("0-0"),
+          ]);
+        }
+      },
+    });
+
+    expect(observed).toEqual([
+      ["", false, false],
+      ["0-0", true, false],
+    ]);
+  });
+
+  it("should provide the position of the whole relevant node for declarations", () => {
+    const code = `import { imp } from 'mod'
+const a = 1
+function foo(param) {}
+try {} catch (err) {}
+class Klass {}
+`;
+
+    const scopeTracker = new TestScopeTracker({ preserveExitedScopes: true });
+
+    parseAndWalk(code, filename, { scopeTracker });
+
+    const imp = scopeTracker.getDeclarationFromScope("imp", "");
+    assert(imp instanceof ScopeTrackerImport);
+    expect(imp.start).toBe(0);
+    expect(imp.end).toBe(code.indexOf("'mod'") + "'mod'".length);
+
+    const a = scopeTracker.getDeclarationFromScope("a", "");
+    assert(a instanceof ScopeTrackerVariable);
+    expect(a.start).toBe(code.indexOf("const a"));
+    expect(a.end).toBe(code.indexOf("const a") + "const a = 1".length);
+
+    const foo = scopeTracker.getDeclarationFromScope("foo", "");
+    assert(foo instanceof ScopeTrackerFunction);
+    expect(foo.start).toBe(code.indexOf("function foo"));
+    expect(foo.end).toBe(code.indexOf("function foo") + "function foo(param) {}".length);
+
+    const param = scopeTracker.getDeclarationFromScope("param", "0");
+    assert(param instanceof ScopeTrackerFunctionParam);
+    expect(param.start).toBe(foo.start);
+    expect(param.end).toBe(foo.end);
+
+    const err = scopeTracker.getDeclarationFromScope("err", "2");
+    assert(err instanceof ScopeTrackerCatchParam);
+    expect(err.start).toBe(code.indexOf("catch"));
+    expect(err.end).toBe(code.indexOf("catch") + "catch (err) {}".length);
+
+    const klass = scopeTracker.getDeclarationFromScope("Klass", "");
+    assert(klass instanceof ScopeTrackerIdentifier);
+    expect(klass.start).toBe(code.indexOf("Klass"));
+    expect(klass.end).toBe(code.indexOf("Klass") + "Klass".length);
+  });
 });
 
 describe("parsing", () => {
@@ -1371,6 +1451,41 @@ describe("reference identifiers", () => {
     expect(getUnmatchedIdentifiers(code)).toEqual(["bar", "baz"]);
   });
 
+  it("should not report function type parameter names as references", () => {
+    const code = `
+    type Fn = (param1: string, param2?: number) => void
+    interface I {
+      (param3: string): void
+      new (param4: string): unknown
+      method(param5: string): void
+    }
+    const ctor: new (param6: string) => unknown = class {}
+    `;
+
+    expect(getUnmatchedIdentifiers(code)).toEqual([]);
+  });
+
+  it("should not report abstract class members as references", () => {
+    const code = `
+    abstract class C1 {
+      abstract prop: string
+      abstract method(param1: string): void
+      abstract get getter(): number
+      abstract accessor accessor1: number
+      abstract [ref1]: string
+    }
+    declare class C2 {
+      method(param2: string): void
+    }
+    class C3 {
+      overloaded(param3: string): void
+      overloaded(param3) { return param3 }
+    }
+    `;
+
+    expect(getUnmatchedIdentifiers(code)).toEqual(["ref1"]);
+  });
+
   it("should declare import equals bindings", () => {
     const code = `
     import A = require('mod')
@@ -1439,6 +1554,89 @@ describe("reference identifiers", () => {
       "Unknown",
       "console",
     ]);
+  });
+
+  it("should handle unnamed declarations and non-identifier module names", () => {
+    expect(getUnmatchedIdentifiers(`export default function () { ref1 }`)).toEqual(["ref1"]);
+    expect(getUnmatchedIdentifiers(`export default class {}`)).toEqual([]);
+    expect(
+      getUnmatchedIdentifiers(`const A = class {}\nconst B = class Named { m() { Named } }`),
+    ).toEqual([]);
+    expect(getUnmatchedIdentifiers(`declare module "mod" {}`)).toEqual([]);
+    expect(getUnmatchedIdentifiers(`try {} catch { ref2 }`)).toEqual(["ref2"]);
+    expect(getUnmatchedIdentifiers(`const [, ...rest] = arr`)).toEqual(["arr"]);
+    expect(getUnmatchedIdentifiers(`enum E { "str" = 1 }`)).toEqual([]);
+    expect(
+      getUnmatchedIdentifiers(`export default function (): void;\nexport default function () {}`),
+    ).toEqual([]);
+  });
+
+  it("should detect references in JSX member expressions", () => {
+    expect(getUnmatchedIdentifiers(`const el = <Foo.Bar.baz />`, "test.tsx")).toEqual(["Foo"]);
+    expect(getUnmatchedIdentifiers(`const el = <foo.bar />`, "test.tsx")).toEqual(["foo"]);
+  });
+
+  it("should not report JSX identifiers as type references", () => {
+    const code = `const el = <Foo prop={bar}>{baz}</Foo>`;
+
+    expect(getUnmatchedIdentifiers(code, "test.tsx", { mode: "type" })).toEqual([]);
+  });
+
+  function collectNodes(code: string, sourceFilename = filename): Node[] {
+    const nodes: Node[] = [];
+    parseAndWalk(code, sourceFilename, {
+      enter(node) {
+        nodes.push(node);
+      },
+    });
+    return nodes;
+  }
+
+  it("should not consider detached nodes to be bindings or references", () => {
+    const identifier = collectNodes("foo").find((n) => n.type === "Identifier");
+    assert(identifier);
+
+    expect(isBindingIdentifier(identifier, null)).toBe(false);
+    expect(isReferenceIdentifier(identifier, null)).toBe(false);
+  });
+
+  it("should match identifiers nested in function parameter patterns", () => {
+    const nodes = collectNodes(
+      `function fn([a = 1, , ...rest], { b: renamed, ...others }, ...variadic) { fn() }`,
+    );
+    const fn = nodes.find((n) => n.type === "FunctionDeclaration");
+    assert(fn);
+    const identifier = (name: string) => {
+      const node = nodes.find((n) => n.type === "Identifier" && n.name === name);
+      assert(node);
+      return node;
+    };
+
+    expect(isBindingIdentifier(identifier("a"), fn)).toBe(true);
+    expect(isBindingIdentifier(identifier("rest"), fn)).toBe(true);
+    expect(isBindingIdentifier(identifier("renamed"), fn)).toBe(true);
+    expect(isBindingIdentifier(identifier("others"), fn)).toBe(true);
+    expect(isBindingIdentifier(identifier("variadic"), fn)).toBe(true);
+    // property keys are not bindings of the function
+    expect(isBindingIdentifier(identifier("b"), fn)).toBe(false);
+  });
+
+  it("should treat constructor parameter properties as bindings of the constructor", () => {
+    const nodes = collectNodes(`class A { constructor(private p = 1) {} }`);
+    const constructorFn = nodes.find((n) => n.type === "FunctionExpression");
+    const parameter = nodes.find((n) => n.type === "Identifier" && n.name === "p");
+    assert(constructorFn && parameter);
+
+    expect(isBindingIdentifier(parameter, constructorFn)).toBe(true);
+  });
+
+  it("should not report JSX identifiers in non-JSX positions", () => {
+    const nodes = collectNodes(`const el = <div />`, "test.tsx");
+    const jsxIdentifier = nodes.find((n) => n.type === "JSXIdentifier");
+    const program = nodes.find((n) => n.type === "Program");
+    assert(jsxIdentifier && program);
+
+    expect(isReferenceIdentifier(jsxIdentifier, program)).toBe(false);
   });
 });
 

--- a/test/scope-tracker.test.ts
+++ b/test/scope-tracker.test.ts
@@ -4,6 +4,7 @@ import type { IsReferenceIdentifierOptions, ScopeTrackerQueryOptions } from "../
 import {
   getUndeclaredIdentifiersInFunction,
   isBindingIdentifier,
+  isOnlyBindingIdentifier,
   isReferenceIdentifier,
   parseAndWalk,
   ScopeTracker,
@@ -1596,6 +1597,7 @@ describe("reference identifiers", () => {
     const identifier = collectNodes("foo").find((n) => n.type === "Identifier");
     assert(identifier);
 
+    expect(isOnlyBindingIdentifier(identifier, null)).toBe(false);
     expect(isBindingIdentifier(identifier, null)).toBe(false);
     expect(isReferenceIdentifier(identifier, null)).toBe(false);
   });
@@ -1612,13 +1614,13 @@ describe("reference identifiers", () => {
       return node;
     };
 
-    expect(isBindingIdentifier(identifier("a"), fn)).toBe(true);
-    expect(isBindingIdentifier(identifier("rest"), fn)).toBe(true);
-    expect(isBindingIdentifier(identifier("renamed"), fn)).toBe(true);
-    expect(isBindingIdentifier(identifier("others"), fn)).toBe(true);
-    expect(isBindingIdentifier(identifier("variadic"), fn)).toBe(true);
+    expect(isOnlyBindingIdentifier(identifier("a"), fn)).toBe(true);
+    expect(isOnlyBindingIdentifier(identifier("rest"), fn)).toBe(true);
+    expect(isOnlyBindingIdentifier(identifier("renamed"), fn)).toBe(true);
+    expect(isOnlyBindingIdentifier(identifier("others"), fn)).toBe(true);
+    expect(isOnlyBindingIdentifier(identifier("variadic"), fn)).toBe(true);
     // property keys are not bindings of the function
-    expect(isBindingIdentifier(identifier("b"), fn)).toBe(false);
+    expect(isOnlyBindingIdentifier(identifier("b"), fn)).toBe(false);
   });
 
   it("should treat constructor parameter properties as bindings of the constructor", () => {
@@ -1627,7 +1629,59 @@ describe("reference identifiers", () => {
     const parameter = nodes.find((n) => n.type === "Identifier" && n.name === "p");
     assert(constructorFn && parameter);
 
-    expect(isBindingIdentifier(parameter, constructorFn)).toBe(true);
+    expect(isOnlyBindingIdentifier(parameter, constructorFn)).toBe(true);
+  });
+
+  // @todo: remove in v2
+  it("should preserve the legacy behavior of the deprecated isBindingIdentifier", () => {
+    const identifiers = new Map<string, { node: Node; parent: Node | null }>();
+    parseAndWalk(
+      `
+      import def, { imp as alias } from 'x'
+      import * as ns from 'y'
+      enum E {}
+      namespace N {}
+      function fn(a) { obj.prop; ({ key: 1, short }); class C { method() {} field = 2 } }
+      `,
+      filename,
+      {
+        enter(node, parent) {
+          if (node.type === "Identifier") {
+            identifiers.set(node.name, { node, parent });
+          }
+        },
+      },
+    );
+    const byName = (name: string) => {
+      const entry = identifiers.get(name);
+      assert(entry);
+      return entry;
+    };
+
+    // binding positions behave the same in both implementations,
+    // including the ones added after the deprecation (imports, enums, namespaces, ...)
+    for (const name of ["fn", "a", "C", "def", "alias", "ns", "E", "N"]) {
+      const { node, parent } = byName(name);
+      expect(isBindingIdentifier(node, parent)).toBe(true);
+      expect(isOnlyBindingIdentifier(node, parent)).toBe(true);
+    }
+
+    // the imported name of `import { imp as alias }` is not a binding
+    const imported = byName("imp");
+    expect(isBindingIdentifier(imported.node, imported.parent)).toBe(false);
+    expect(isOnlyBindingIdentifier(imported.node, imported.parent)).toBe(false);
+
+    // non-reference positions the legacy implementation also reports as bindings
+    for (const name of ["prop", "key", "method", "field"]) {
+      const { node, parent } = byName(name);
+      expect(isBindingIdentifier(node, parent)).toBe(true);
+      expect(isOnlyBindingIdentifier(node, parent)).toBe(false);
+    }
+
+    // shorthand property values are references in both
+    const short = byName("short");
+    expect(isBindingIdentifier(short.node, short.parent)).toBe(false);
+    expect(isOnlyBindingIdentifier(short.node, short.parent)).toBe(false);
   });
 
   it("should not report JSX identifiers in non-JSX positions", () => {

--- a/test/walker.test.ts
+++ b/test/walker.test.ts
@@ -841,4 +841,180 @@ describe("oxc-walker", () => {
       ]
     `);
   });
+
+  function getWalkedNodeStrings(node: Node) {
+    const walkedNodes: string[] = [];
+    walk(node, {
+      enter(node) {
+        walkedNodes.push(getNodeString(node));
+      },
+    });
+    return walkedNodes;
+  }
+
+  it("ignores non-node input", () => {
+    const walkedNodes: string[] = [];
+    const result = walk({ answer: 42 } as unknown as Node, {
+      enter(node) {
+        walkedNodes.push(getNodeString(node));
+      },
+    });
+
+    expect(result).toBeNull();
+    expect(walkedNodes).toEqual([]);
+  });
+
+  it("removes the root node and returns null", () => {
+    const ast: Node = { type: "Identifier", name: "x", start: 0, end: 1 };
+
+    const result = walk(ast, {
+      enter() {
+        this.remove();
+      },
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it("returns the replacement when the root node is removed in enter and replaced in leave", () => {
+    const ast: Node = { type: "Identifier", name: "x", start: 0, end: 1 };
+    const replacement: Node = { type: "Literal", value: 1, raw: "1", start: 0, end: 1 };
+
+    const result = walk(ast, {
+      enter() {
+        this.remove();
+      },
+      leave(node) {
+        if (node.type === "Identifier") {
+          this.replace(replacement);
+        }
+      },
+    });
+
+    expect(result).toBe(replacement);
+  });
+
+  it("replaces nodes at non-array positions", () => {
+    const { program } = parseAndWalk("const a = 1", "test.js", {
+      enter(node) {
+        if (node.type === "Literal") {
+          this.replace({ ...node, value: 2, raw: "2" });
+        }
+      },
+    });
+
+    expect(getWalkedNodeStrings(program)).toEqual([
+      "Program",
+      "VariableDeclaration",
+      "VariableDeclarator",
+      "Identifier:a",
+      "Literal:2",
+    ]);
+  });
+
+  it("removes nodes at non-array positions", () => {
+    const { program } = parseAndWalk("const a = 1", "test.js", {
+      enter(node) {
+        if (node.type === "Literal") {
+          this.remove();
+        }
+      },
+    });
+
+    expect(getWalkedNodeStrings(program)).toEqual([
+      "Program",
+      "VariableDeclaration",
+      "VariableDeclarator",
+      "Identifier:a",
+    ]);
+  });
+
+  it("supports replacing nodes in leave", () => {
+    const { program } = parseAndWalk('console.log("hello world")', "test.js", {
+      leave(node) {
+        if (node.type === "Literal") {
+          this.replace({ ...node, value: "replaced" });
+        }
+      },
+    });
+
+    expect(getWalkedNodeStrings(program)).toEqual([
+      "Program",
+      "ExpressionStatement",
+      "CallExpression",
+      "MemberExpression",
+      "Identifier:console",
+      "Identifier:log",
+      "Literal:replaced",
+    ]);
+  });
+
+  it("supports removing nodes in leave", () => {
+    const { program } = parseAndWalk("let a, b, c", "test.js", {
+      leave(node) {
+        if (
+          node.type === "VariableDeclarator" &&
+          node.id.type === "Identifier" &&
+          node.id.name !== "c"
+        ) {
+          this.remove();
+        }
+      },
+    });
+
+    expect(getWalkedNodeStrings(program)).toEqual([
+      "Program",
+      "VariableDeclaration",
+      "VariableDeclarator",
+      "Identifier:c",
+    ]);
+  });
+
+  it("inserts the replacement when a node removed in enter is replaced in leave", () => {
+    const { program } = parseAndWalk('console.log("hello world")', "test.js", {
+      enter(node) {
+        if (node.type === "Literal") {
+          this.remove();
+        }
+      },
+      leave(node) {
+        if (node.type === "Literal") {
+          this.replace({ ...node, value: "restored" });
+        }
+      },
+    });
+
+    expect(getWalkedNodeStrings(program)).toEqual([
+      "Program",
+      "ExpressionStatement",
+      "CallExpression",
+      "MemberExpression",
+      "Identifier:console",
+      "Identifier:log",
+      "Literal:restored",
+    ]);
+  });
+
+  it("inserts the replacement at non-array positions when removed in enter and replaced in leave", () => {
+    const { program } = parseAndWalk("const a = 1", "test.js", {
+      enter(node) {
+        if (node.type === "Literal") {
+          this.remove();
+        }
+      },
+      leave(node) {
+        if (node.type === "Literal") {
+          this.replace({ ...node, value: 2, raw: "2" });
+        }
+      },
+    });
+
+    expect(getWalkedNodeStrings(program)).toEqual([
+      "Program",
+      "VariableDeclaration",
+      "VariableDeclarator",
+      "Identifier:a",
+      "Literal:2",
+    ]);
+  });
 });


### PR DESCRIPTION
while investigating https://github.com/nuxt/nuxt/issues/35858, I noticed that we have some gaps in `oxc-walker` and that there are some incorrect assumptions in `isBindingIdentifier`.

we often used `!isBindingIdentifier()` to identify **reference** identifiers, which was incorrect in several cases.
this PR adds a new function `isReferenceIdentifier`, `isOnlyBindingIdentifier` which behaves consistently with its name, and deprecates the old incorrect `isBindingIdentifier`

additionally, there is also a new `mode?: 'value' | 'type' | 'all'` option in the relevant `ScopeTracker` methods to target either runtime identifiers, type identifiers, or both.