### PR TITLE
perf: optimize walker & scope tracker

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://unpkg.com/knip@5/schema.json",
   "exclude": ["catalog"],
-  "entry": ["src/index.ts", "vite.config.ts", "test/**/*.test.ts"],
-  "ignoreDependencies": ["@vitest/coverage-v8"]
+  "entry": ["src/index.ts", "vite.config.ts", "test/**/*.test.ts", "test/**/*.bench.ts"],
+  "ignoreDependencies": ["@vitest/coverage-v8", "@vue/compiler-sfc"]
 }

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@oxc-project/types": "0.142.0",
     "@types/node": "24.10.3",
     "@vitest/coverage-v8": "4.1.10",
+    "@vue/compiler-sfc": "3.5.40",
     "knip": "^6.0.0",
     "oxc-parser": "0.142.0",
     "typescript": "7.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,6 +31,9 @@ importers:
       '@vitest/coverage-v8':
         specifier: 4.1.10
         version: 4.1.10(@vitest/browser@4.1.10)(vitest@4.1.10)
+      '@vue/compiler-sfc':
+        specifier: 3.5.40
+        version: 3.5.40
       knip:
         specifier: ^6.0.0
         version: 6.29.0
@@ -60,6 +63,10 @@ packages:
     resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-string-parser@7.29.7':
+    resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-validator-identifier@7.29.7':
     resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
     engines: {node: '>=6.9.0'}
@@ -69,12 +76,21 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
+  '@babel/parser@7.29.7':
+    resolution: {integrity: sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
   '@babel/runtime@7.29.7':
     resolution: {integrity: sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==}
     engines: {node: '>=6.9.0'}
 
   '@babel/types@7.29.0':
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.29.7':
+    resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
     engines: {node: '>=6.9.0'}
 
   '@bcoe/v8-coverage@1.0.2':
@@ -1472,6 +1488,21 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@vue/compiler-core@3.5.40':
+    resolution: {integrity: sha512-39E8IgOhTbVDnoJFMKc2DvYnypcZwUqgUhQkccva/0m6FUwtIKSGV7n1hpVmYcFaoRAwf9pBcwnKlCEsN63ZEQ==}
+
+  '@vue/compiler-dom@3.5.40':
+    resolution: {integrity: sha512-pwkx4vqlqOspFstrcmzwkKLePVMD3PT65imRzLhanU2V1Fj4K13g6OXjanOyzw3aTAuRk84BOmY8f3rEHqPaVA==}
+
+  '@vue/compiler-sfc@3.5.40':
+    resolution: {integrity: sha512-gIf497P4kpuALcvs5n3AEg1Vdn0pSY4XbjASIfHNYF1/MP3T2Mf2STERTubysBxCRxzJGJYtF/O7vwJrxFB3Vw==}
+
+  '@vue/compiler-ssr@3.5.40':
+    resolution: {integrity: sha512-rrE5xiXG663+vHCHa3J9p2z5OcBRjXmoqenprJxAFQxg5pSshzeBiCE6pu46axapRJ2Adk0YDA2BRZVjiHXnhg==}
+
+  '@vue/shared@3.5.40':
+    resolution: {integrity: sha512-WxnBtruIqOoV3rA4jeKDWzrYI5h7Cp4+pjwDi8kWGHz+IslhiN+wguLVVhtv2l8VoU02rzDCVfDjgCl1lNpZVg==}
+
   '@yuku-codegen/binding-darwin-arm64@0.5.48':
     resolution: {integrity: sha512-yo96Oef12WzqnphInfz/eexVse3+kWgfGS5g2S3rFS3dcGn1ENW9xLFDZUP9rh+yP76DOq38wBoFi1+I9+6qBg==}
     cpu: [arm64]
@@ -1633,6 +1664,10 @@ packages:
   dom-accessibility-api@0.5.16:
     resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
 
+  entities@7.0.1:
+    resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
+    engines: {node: '>=0.12'}
+
   es-module-lexer@2.1.0:
     resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
 
@@ -1640,6 +1675,9 @@ packages:
     resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
     engines: {node: '>=18'}
     hasBin: true
+
+  estree-walker@2.0.2:
+    resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
 
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
@@ -2098,17 +2136,28 @@ snapshots:
 
   '@babel/helper-string-parser@7.27.1': {}
 
+  '@babel/helper-string-parser@7.29.7': {}
+
   '@babel/helper-validator-identifier@7.29.7': {}
 
   '@babel/parser@7.29.0':
     dependencies:
       '@babel/types': 7.29.0
 
+  '@babel/parser@7.29.7':
+    dependencies:
+      '@babel/types': 7.29.7
+
   '@babel/runtime@7.29.7': {}
 
   '@babel/types@7.29.0':
     dependencies:
       '@babel/helper-string-parser': 7.27.1
+      '@babel/helper-validator-identifier': 7.29.7
+
+  '@babel/types@7.29.7':
+    dependencies:
+      '@babel/helper-string-parser': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
 
   '@bcoe/v8-coverage@1.0.2': {}
@@ -2931,6 +2980,38 @@ snapshots:
   '@voidzero-dev/vite-plus-win32-x64-msvc@0.2.6':
     optional: true
 
+  '@vue/compiler-core@3.5.40':
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@vue/shared': 3.5.40
+      entities: 7.0.1
+      estree-walker: 2.0.2
+      source-map-js: 1.2.1
+
+  '@vue/compiler-dom@3.5.40':
+    dependencies:
+      '@vue/compiler-core': 3.5.40
+      '@vue/shared': 3.5.40
+
+  '@vue/compiler-sfc@3.5.40':
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@vue/compiler-core': 3.5.40
+      '@vue/compiler-dom': 3.5.40
+      '@vue/compiler-ssr': 3.5.40
+      '@vue/shared': 3.5.40
+      estree-walker: 2.0.2
+      magic-string: 0.30.21
+      postcss: 8.5.23
+      source-map-js: 1.2.1
+
+  '@vue/compiler-ssr@3.5.40':
+    dependencies:
+      '@vue/compiler-dom': 3.5.40
+      '@vue/shared': 3.5.40
+
+  '@vue/shared@3.5.40': {}
+
   '@yuku-codegen/binding-darwin-arm64@0.5.48':
     optional: true
 
@@ -3025,6 +3106,8 @@ snapshots:
 
   dom-accessibility-api@0.5.16: {}
 
+  entities@7.0.1: {}
+
   es-module-lexer@2.1.0: {}
 
   esbuild@0.25.12:
@@ -3055,6 +3138,8 @@ snapshots:
       '@esbuild/win32-arm64': 0.25.12
       '@esbuild/win32-ia32': 0.25.12
       '@esbuild/win32-x64': 0.25.12
+
+  estree-walker@2.0.2: {}
 
   estree-walker@3.0.3:
     dependencies:

--- a/src/scope-tracker.ts
+++ b/src/scope-tracker.ts
@@ -1,12 +1,17 @@
 import type {
   ArrowFunctionExpression,
+  BindingPattern,
+  BindingRestElement,
   CatchClause,
+  FormalParameterRest,
   Function,
   IdentifierReference,
   ImportDeclaration,
   ImportDeclarationSpecifier,
   JSXIdentifier,
   Node,
+  ParamPattern,
+  TSParameterProperty,
   VariableDeclaration,
 } from "@oxc-project/types";
 import type { Identifier } from "./walk";
@@ -16,6 +21,33 @@ export interface ScopeTrackerProtected {
   processNodeEnter: (node: Node) => void;
   processNodeLeave: (node: Node) => void;
 }
+
+const SCOPE_ENTER_TYPES = new Set([
+  "Program",
+  "BlockStatement",
+  "StaticBlock",
+  "TSModuleBlock",
+  "FunctionDeclaration",
+  "FunctionExpression",
+  "ArrowFunctionExpression",
+  "VariableDeclaration",
+  "ClassDeclaration",
+  "ClassExpression",
+  "ImportDeclaration",
+  "TSEnumDeclaration",
+  "TSModuleDeclaration",
+  "TSImportEqualsDeclaration",
+  "TSDeclareFunction",
+  "TSInterfaceDeclaration",
+  "TSTypeAliasDeclaration",
+  "TSTypeParameter",
+  "TSMappedType",
+  "TSEnumBody",
+  "CatchClause",
+  "ForStatement",
+  "ForOfStatement",
+  "ForInStatement",
+]);
 
 /**
  * Tracks variable scopes and identifier declarations within a JavaScript AST.
@@ -69,6 +101,20 @@ export interface ScopeTrackerProtected {
  */
 export class ScopeTracker {
   protected scopeIndexStack: number[] = [];
+  /**
+   * The scope keys of the ancestors of the current scope, one entry per active scope.
+   * `pushScope` pushes the current `scopeIndexKey` before deriving the new one,
+   * and `popScope` restores it from here, so the stack always mirrors the path
+   * from the root scope down to the parent of the current scope.
+   */
+  protected scopeKeyStack: string[] = [];
+  /**
+   * The nodes that created the currently active scopes, one entry per scope.
+   * A node that creates multiple scopes (e.g. `FunctionExpression`) appears once per scope.
+   * This lets `processNodeLeave` detect scope ends with a pointer comparison
+   * instead of checking the node type.
+   */
+  protected scopeOwnerStack: Node[] = [];
   protected scopeIndexKey = "";
   protected scopes: Map<string, Map<string, ScopeTrackerNode>> = new Map();
   protected typeScopes: Map<string, Map<string, ScopeTrackerNode>> = new Map();
@@ -80,16 +126,20 @@ export class ScopeTracker {
     this.options = options;
   }
 
-  protected updateScopeIndexKey() {
-    this.scopeIndexKey = this.scopeIndexStack.slice(0, -1).join("-");
-  }
-
-  protected pushScope() {
+  protected pushScope(owner: Node) {
+    const depthIndex = this.scopeIndexStack[this.scopeIndexStack.length - 1];
+    this.scopeKeyStack.push(this.scopeIndexKey);
+    this.scopeOwnerStack.push(owner);
     this.scopeIndexStack.push(0);
-    this.updateScopeIndexKey();
+    if (depthIndex !== undefined) {
+      this.scopeIndexKey = this.scopeIndexKey
+        ? `${this.scopeIndexKey}-${depthIndex}`
+        : `${depthIndex}`;
+    }
   }
 
   protected popScope() {
+    this.scopeOwnerStack.pop();
     this.scopeIndexStack.pop();
     if (this.scopeIndexStack[this.scopeIndexStack.length - 1] !== undefined) {
       this.scopeIndexStack[this.scopeIndexStack.length - 1]!++;
@@ -100,7 +150,7 @@ export class ScopeTracker {
       this.typeScopes.delete(this.scopeIndexKey);
     }
 
-    this.updateScopeIndexKey();
+    this.scopeIndexKey = this.scopeKeyStack.pop() ?? "";
   }
 
   protected declareInNamespace(
@@ -133,7 +183,7 @@ export class ScopeTracker {
     }
   }
 
-  protected declareFunctionParameter(param: Node, fn: Function | ArrowFunctionExpression) {
+  protected declareFunctionParameter(param: ParamPattern, fn: Function | ArrowFunctionExpression) {
     if (this.isFrozen) {
       return;
     }
@@ -148,7 +198,7 @@ export class ScopeTracker {
   }
 
   protected declarePattern(
-    pattern: Node,
+    pattern: BindingPattern,
     parent: VariableDeclaration | ArrowFunctionExpression | CatchClause | Function,
   ) {
     if (this.isFrozen) {
@@ -169,12 +219,16 @@ export class ScopeTracker {
   }
 
   protected processNodeEnter: ScopeTrackerProtected["processNodeEnter"] = (node) => {
+    // perf: fast path for the nodes, which do not affect scopes (avoiding unnecessary comparisons)
+    if (!SCOPE_ENTER_TYPES.has(node.type)) {
+      return;
+    }
     switch (node.type) {
       case "Program":
       case "BlockStatement":
       case "StaticBlock":
       case "TSModuleBlock":
-        this.pushScope();
+        this.pushScope(node);
         break;
 
       case "FunctionDeclaration":
@@ -182,7 +236,7 @@ export class ScopeTracker {
         if (node.id?.name) {
           this.declareIdentifier(node.id.name, new ScopeTrackerFunction(node, this.scopeIndexKey));
         }
-        this.pushScope();
+        this.pushScope(node);
         for (const param of node.params) {
           this.declareFunctionParameter(param, node);
         }
@@ -191,19 +245,19 @@ export class ScopeTracker {
       case "FunctionExpression":
         // make the name of the function available only within the function
         // e.g. const foo = function bar() {  // bar is only available within the function body
-        this.pushScope();
+        this.pushScope(node);
         // can be undefined, for example, in class method definitions
         if (node.id?.name) {
           this.declareIdentifier(node.id.name, new ScopeTrackerFunction(node, this.scopeIndexKey));
         }
 
-        this.pushScope();
+        this.pushScope(node);
         for (const param of node.params) {
           this.declareFunctionParameter(param, node);
         }
         break;
       case "ArrowFunctionExpression":
-        this.pushScope();
+        this.pushScope(node);
         for (const param of node.params) {
           this.declareFunctionParameter(param, node);
         }
@@ -227,14 +281,14 @@ export class ScopeTracker {
         }
         // a scope is pushed for generic classes so that their type parameters do not leak out
         if (node.typeParameters) {
-          this.pushScope();
+          this.pushScope(node);
         }
         break;
 
       case "ClassExpression":
         // make the name of the class available only within the class
         // e.g. const MyClass = class InternalClassName { // InternalClassName is only available within the class body
-        this.pushScope();
+        this.pushScope(node);
         if (node.id?.name) {
           this.declareIdentifier(
             node.id.name,
@@ -280,7 +334,7 @@ export class ScopeTracker {
             new ScopeTrackerIdentifier(node.id, this.scopeIndexKey),
           );
         }
-        this.pushScope();
+        this.pushScope(node);
         break;
 
       case "TSInterfaceDeclaration":
@@ -294,7 +348,7 @@ export class ScopeTracker {
             { type: true },
           );
         }
-        this.pushScope();
+        this.pushScope(node);
         break;
 
       case "TSTypeParameter":
@@ -311,7 +365,7 @@ export class ScopeTracker {
       case "TSMappedType":
         // the key of a mapped type declares a type parameter scoped to the mapped type
         // (`{ [K in keyof T]: K }`)
-        this.pushScope();
+        this.pushScope(node);
         this.declareIdentifier(
           node.key.name,
           new ScopeTrackerIdentifier(node.key, this.scopeIndexKey),
@@ -321,7 +375,7 @@ export class ScopeTracker {
 
       case "TSEnumBody":
         // enum members are referencable by name within the enum body
-        this.pushScope();
+        this.pushScope(node);
         for (const member of node.members) {
           if (member.id.type === "Identifier") {
             this.declareIdentifier(
@@ -333,7 +387,7 @@ export class ScopeTracker {
         break;
 
       case "CatchClause":
-        this.pushScope();
+        this.pushScope(node);
         if (node.param) {
           this.declarePattern(node.param, node);
         }
@@ -344,7 +398,7 @@ export class ScopeTracker {
       case "ForInStatement":
         // make the variables defined in for loops available only within the loop
         // e.g. for (let i = 0; i < 10; i++) { // i is only available within the loop block scope
-        this.pushScope();
+        this.pushScope(node);
 
         if (node.type === "ForStatement" && node.init?.type === "VariableDeclaration") {
           for (const decl of node.init.declarations) {
@@ -363,34 +417,11 @@ export class ScopeTracker {
   };
 
   protected processNodeLeave: ScopeTrackerProtected["processNodeLeave"] = (node) => {
-    switch (node.type) {
-      case "Program":
-      case "BlockStatement":
-      case "CatchClause":
-      case "FunctionDeclaration":
-      case "ArrowFunctionExpression":
-      case "StaticBlock":
-      case "TSModuleBlock":
-      case "TSEnumBody":
-      case "TSInterfaceDeclaration":
-      case "TSTypeAliasDeclaration":
-      case "TSDeclareFunction":
-      case "TSMappedType":
-      case "ClassExpression":
-      case "ForStatement":
-      case "ForOfStatement":
-      case "ForInStatement":
-        this.popScope();
-        break;
-      case "FunctionExpression":
-        this.popScope();
-        this.popScope();
-        break;
-      case "ClassDeclaration":
-        if (node.typeParameters) {
-          this.popScope();
-        }
-        break;
+    // pop every scope this node created on enter
+    // perf: a pointer comparison instead of checking `node.type`
+    const owners = this.scopeOwnerStack;
+    while (owners.length > 0 && owners[owners.length - 1] === node) {
+      this.popScope();
     }
   };
 
@@ -398,18 +429,18 @@ export class ScopeTracker {
     scopes: Map<string, Map<string, ScopeTrackerNode>>,
     name: string,
   ): ScopeTrackerNode | null {
-    if (!this.scopeIndexKey) {
-      return scopes.get("")?.get(name) ?? null;
-    }
-
-    const indices = this.scopeIndexKey.split("-").map(Number);
-    for (let i = indices.length; i >= 0; i--) {
-      const node = scopes.get(indices.slice(0, i).join("-"))?.get(name);
+    let key = this.scopeIndexKey;
+    while (true) {
+      const node = scopes.get(key)?.get(name);
       if (node) {
         return node;
       }
+      if (!key) {
+        return null;
+      }
+      const separatorIndex = key.lastIndexOf("-");
+      key = separatorIndex === -1 ? "" : key.slice(0, separatorIndex);
     }
-    return null;
   }
 
   /**
@@ -466,14 +497,18 @@ export class ScopeTracker {
   freeze() {
     this.isFrozen = true;
     this.scopeIndexStack = [];
-    this.updateScopeIndexKey();
+    this.scopeKeyStack = [];
+    this.scopeOwnerStack = [];
+    this.scopeIndexKey = "";
   }
 }
 
-function getPatternIdentifiers(pattern: Node) {
+type Pattern = BindingPattern | BindingRestElement | FormalParameterRest | TSParameterProperty;
+
+function getPatternIdentifiers(pattern: Pattern) {
   const identifiers: Identifier[] = [];
 
-  function collectIdentifiers(pattern: Node) {
+  function collectIdentifiers(pattern: Pattern) {
     switch (pattern.type) {
       case "Identifier":
         identifiers.push(pattern);
@@ -508,6 +543,44 @@ function getPatternIdentifiers(pattern: Node) {
 }
 
 /**
+ * An allocation-free alternative to `getPatternIdentifiers(pattern).includes(node)`
+ */
+function isIdentifierInPattern(pattern: Pattern, node: Node): boolean {
+  switch (pattern.type) {
+    case "Identifier":
+      return pattern === node;
+    case "AssignmentPattern":
+      return isIdentifierInPattern(pattern.left, node);
+    case "RestElement":
+      return isIdentifierInPattern(pattern.argument, node);
+    case "TSParameterProperty":
+      return isIdentifierInPattern(pattern.parameter, node);
+    case "ArrayPattern":
+      for (const element of pattern.elements) {
+        if (
+          element &&
+          isIdentifierInPattern(element.type === "RestElement" ? element.argument : element, node)
+        ) {
+          return true;
+        }
+      }
+      return false;
+    case "ObjectPattern":
+      for (const property of pattern.properties) {
+        if (
+          isIdentifierInPattern(
+            property.type === "RestElement" ? property.argument : property.value,
+            node,
+          )
+        ) {
+          return true;
+        }
+      }
+      return false;
+  }
+}
+
+/**
  * Check if an identifier is in a binding position, where it declares a new variable.
  *
  * Note that identifiers nested in destructuring patterns (`const { a, b = c } = obj`)
@@ -531,12 +604,9 @@ export function isOnlyBindingIdentifier(node: Node, parent: Node | null) {
       if (parent.type !== "ArrowFunctionExpression" && parent.id === node) {
         return true;
       }
-      if (parent.params.length) {
-        for (const param of parent.params) {
-          const identifiers = getPatternIdentifiers(param);
-          if (identifiers.includes(node)) {
-            return true;
-          }
+      for (const param of parent.params) {
+        if (isIdentifierInPattern(param, node)) {
+          return true;
         }
       }
       return false;
@@ -548,14 +618,14 @@ export function isOnlyBindingIdentifier(node: Node, parent: Node | null) {
 
     case "VariableDeclarator":
       // variable name
-      return getPatternIdentifiers(parent.id).includes(node);
+      return isIdentifierInPattern(parent.id, node);
 
     case "CatchClause":
       // catch clause param
       if (!parent.param) {
         return false;
       }
-      return getPatternIdentifiers(parent.param).includes(node);
+      return isIdentifierInPattern(parent.param, node);
 
     case "ImportSpecifier":
       // the local name of an import
@@ -576,7 +646,7 @@ export function isOnlyBindingIdentifier(node: Node, parent: Node | null) {
 
     case "TSParameterProperty":
       // constructor parameter properties (`constructor(private foo) {}`)
-      return getPatternIdentifiers(parent.parameter).includes(node);
+      return isIdentifierInPattern(parent.parameter, node);
   }
 
   return false;

--- a/src/scope-tracker.ts
+++ b/src/scope-tracker.ts
@@ -22,7 +22,12 @@ export interface ScopeTrackerProtected {
   processNodeLeave: (node: Node) => void;
 }
 
-const SCOPE_ENTER_TYPES = new Set([
+/**
+ * The node types handled by {@link ScopeTracker.processNodeEnter}.
+ * Must list every `case` of its switch statement; a missing entry silently disables
+ * scope tracking for that node type (see the drift test in `test/scope-tracker.test.ts`).
+ */
+const SCOPE_ENTER_TYPES = new Set<Node["type"]>([
   "Program",
   "BlockStatement",
   "StaticBlock",
@@ -578,6 +583,8 @@ function isIdentifierInPattern(pattern: Pattern, node: Node): boolean {
       }
       return false;
   }
+
+  return false;
 }
 
 /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,10 +1,5 @@
 import type { Node } from "@oxc-project/types";
 
 export function isNode(v: unknown): v is Node {
-  return (
-    v !== null &&
-    typeof v === "object" &&
-    (v as any).type != null &&
-    typeof (v as any).type === "string"
-  );
+  return v !== null && typeof v === "object" && typeof (v as any).type === "string";
 }

--- a/src/walker/sync.ts
+++ b/src/walker/sync.ts
@@ -39,25 +39,29 @@ export class WalkerSync extends WalkerBase {
   traverse(input: any, key?: keyof Node, index?: number | null, parent?: Node | null): Node | null {
     const ast = input;
     const ctx: WalkerCallbackContext = { key: null, index: index ?? null, ast };
-    const hasScopeTracker = !!this.scopeTracker;
+
+    // perf: store in local variables to prevent repeated property access
+    const scopeTracker = this.scopeTracker;
+    const enter = this.enter;
+    const leave = this.leave;
+    const contextEnter = this.contextEnter;
+    const contextLeave = this.contextLeave;
 
     const _walk = (
-      input: unknown,
+      input: Node,
       parent: Node | null,
       key: keyof Node | null,
       index: number | null,
       skip: boolean,
-    ) => {
-      if (!isNode(input)) {
-        return null;
+    ): Node | null => {
+      if (scopeTracker) {
+        scopeTracker.processNodeEnter(input);
       }
-
-      this.scopeTracker?.processNodeEnter(input);
       let currentNode: Node | null = input;
       let removedInEnter = false;
       let skipChildren = skip;
 
-      if (this.enter && !skip) {
+      if (enter && !skip) {
         const _skip = this._skip;
         const _remove = this._remove;
         const _replacement = this._replacement;
@@ -68,7 +72,7 @@ export class WalkerSync extends WalkerBase {
 
         ctx.key = key;
         ctx.index = index;
-        this.enter.call(this.contextEnter, input, parent, ctx);
+        enter.call(contextEnter, input, parent, ctx);
 
         if (this._replacement && !this._remove) {
           currentNode = this._replacement;
@@ -92,8 +96,12 @@ export class WalkerSync extends WalkerBase {
 
       // walk the child nodes of the current node or the replaced new node
       // (we need to walk everything when scope tracking)
-      if ((!skipChildren || hasScopeTracker) && currentNode) {
+      if ((!skipChildren || scopeTracker) && currentNode) {
         for (const k in currentNode) {
+          // perf: every node has these scalar keys, skip them before loading the value
+          if (k === "type" || k === "start" || k === "end") {
+            continue;
+          }
           const node = currentNode[k as keyof typeof currentNode];
           if (!node || typeof node !== "object") {
             continue;
@@ -109,15 +117,18 @@ export class WalkerSync extends WalkerBase {
                 }
               }
             }
-          } else if (isNode(node)) {
+            // perf: `node.type` check is the only one which hasn't been checked yet. check only that instead of `isNode`
+          } else if (typeof node.type === "string") {
             _walk(node, currentNode, k as keyof Node, null, skipChildren);
           }
         }
       }
 
-      this.scopeTracker?.processNodeLeave(input);
+      if (scopeTracker) {
+        scopeTracker.processNodeLeave(input);
+      }
 
-      if (this.leave && !skip) {
+      if (leave && !skip) {
         const _replacement = this._replacement;
         const _remove = this._remove;
         this._replacement = null;
@@ -125,7 +136,7 @@ export class WalkerSync extends WalkerBase {
 
         ctx.key = key;
         ctx.index = index;
-        this.leave.call(this.contextLeave, input, parent, ctx);
+        leave.call(contextLeave, input, parent, ctx);
 
         if (this._replacement && !this._remove) {
           currentNode = this._replacement;
@@ -148,6 +159,10 @@ export class WalkerSync extends WalkerBase {
       return currentNode;
     };
 
+    // perf: check the root node before walking
+    if (!isNode(input)) {
+      return null;
+    }
     return _walk(input, parent ?? null, key ?? null, index ?? null, false);
   }
 }

--- a/src/walker/sync.ts
+++ b/src/walker/sync.ts
@@ -182,13 +182,8 @@ export class WalkerSync extends WalkerBase {
           if (Array.isArray(node)) {
             for (let i = 0; i < node.length; i++) {
               const child = node[i];
-              // perf: array elements can be holes (`null`) or non-node objects, so they need
-              // the same guards as the single-value branch below
-              if (!child || typeof child !== "object") {
-                continue;
-              }
-              if (typeof (child as Node).type === "string") {
-                _walkScopesOnly(child as Node);
+              if (isNode(child)) {
+                _walkScopesOnly(child);
               }
             }
 

--- a/src/walker/sync.ts
+++ b/src/walker/sync.ts
@@ -168,7 +168,7 @@ export class WalkerSync extends WalkerBase {
     // so a minimal recursion without the callback bookkeeping is enough
     if (scopeTracker && !enter && !leave) {
       const _walkScopesOnly = (input: Node): void => {
-        scopeTracker!.processNodeEnter(input);
+        scopeTracker.processNodeEnter(input);
         for (const k in input) {
           // perf: every node has these scalar keys, skip them before loading the value
           if (k === "type" || k === "start" || k === "end") {
@@ -182,8 +182,13 @@ export class WalkerSync extends WalkerBase {
           if (Array.isArray(node)) {
             for (let i = 0; i < node.length; i++) {
               const child = node[i];
-              if (isNode(child)) {
-                _walkScopesOnly(child);
+              // perf: array elements can be holes (`null`) or non-node objects, so they need
+              // the same guards as the single-value branch below
+              if (!child || typeof child !== "object") {
+                continue;
+              }
+              if (typeof (child as Node).type === "string") {
+                _walkScopesOnly(child as Node);
               }
             }
 
@@ -192,7 +197,7 @@ export class WalkerSync extends WalkerBase {
             _walkScopesOnly(node as Node);
           }
         }
-        scopeTracker!.processNodeLeave(input);
+        scopeTracker.processNodeLeave(input);
       };
 
       _walkScopesOnly(input);

--- a/src/walker/sync.ts
+++ b/src/walker/sync.ts
@@ -163,6 +163,42 @@ export class WalkerSync extends WalkerBase {
     if (!isNode(input)) {
       return null;
     }
+
+    // perf: without enter/leave handlers no node can be skipped, removed or replaced,
+    // so a minimal recursion without the callback bookkeeping is enough
+    if (scopeTracker && !enter && !leave) {
+      const _walkScopesOnly = (input: Node): void => {
+        scopeTracker!.processNodeEnter(input);
+        for (const k in input) {
+          // perf: every node has these scalar keys, skip them before loading the value
+          if (k === "type" || k === "start" || k === "end") {
+            continue;
+          }
+          const node = input[k as keyof typeof input] as unknown;
+          if (!node || typeof node !== "object") {
+            continue;
+          }
+
+          if (Array.isArray(node)) {
+            for (let i = 0; i < node.length; i++) {
+              const child = node[i];
+              if (isNode(child)) {
+                _walkScopesOnly(child);
+              }
+            }
+
+            // perf: `node.type` check is the only one which hasn't been checked yet. check only that instead of `isNode`
+          } else if (typeof (node as Node).type === "string") {
+            _walkScopesOnly(node as Node);
+          }
+        }
+        scopeTracker!.processNodeLeave(input);
+      };
+
+      _walkScopesOnly(input);
+      return input;
+    }
+
     return _walk(input, parent ?? null, key ?? null, index ?? null, false);
   }
 }

--- a/test/scope-tracker.test.ts
+++ b/test/scope-tracker.test.ts
@@ -1728,6 +1728,106 @@ describe("reference identifiers", () => {
   });
 });
 
+describe("optimized scope tracking without callbacks", () => {
+  it("should produce identical scope data to a walk with a no-op callback", () => {
+    const code = `
+    import { imported } from "module"
+    const topLevel = 1
+    const [, holey = imported, ...restOfIt] = [, 2]
+    function outer(param, { destructured, nested: [inArray] }) {
+      const inner = param + topLevel
+      try {
+        inner.toString()
+      }
+      catch (err) {
+        err.toString()
+      }
+      for (const item of []) {
+        item.toString()
+      }
+      return function named() { return inner }
+    }
+    const arrow = (withDefault = 1) => withDefault
+    class Klass {
+      method(methodParam) { return methodParam }
+    }
+    const expr = class NamedExpr {}
+    interface Iface { prop: string }
+    type Alias<T> = T[]
+    enum Enum { A, B }
+    // non-node object and primitive values: \`regex\` of a regexp literal and
+    // \`value\` of template quasis are plain objects without a \`type\`,
+    // a bigint value is a non-object primitive
+    const re = /ab+c/gi
+    const tpl = \`x\${re.source}y\`
+    const big = 10n
+    `;
+
+    const snapshot = (tracker: TestScopeTracker) =>
+      [...tracker.getScopes().entries()].map(([scope, declarations]) => [
+        scope,
+        [...declarations.entries()].map(([name, node]) => `${name}:${node.type}`),
+      ]);
+
+    const fastTracker = new TestScopeTracker({ preserveExitedScopes: true });
+    const { program } = parseAndWalk(code, filename, { scopeTracker: fastTracker });
+
+    const enterTracker = new TestScopeTracker({ preserveExitedScopes: true });
+    walk(program, { scopeTracker: enterTracker, enter() {} });
+
+    const leaveTracker = new TestScopeTracker({ preserveExitedScopes: true });
+    walk(program, { scopeTracker: leaveTracker, leave() {} });
+
+    const expected = snapshot(enterTracker);
+    expect(expected.flatMap(([, declarations]) => declarations).length).toBeGreaterThan(10);
+    expect(snapshot(fastTracker)).toStrictEqual(expected);
+    expect(snapshot(leaveTracker)).toStrictEqual(expected);
+  });
+
+  it("should return the root node", () => {
+    const { program } = parseAndWalk("const a = 1", filename, {});
+    expect(walk(program, { scopeTracker: new ScopeTracker() })).toBe(program);
+  });
+
+  it("should track declarations from array patterns with holes", () => {
+    const code = `const [, second, ...rest] = [, 1, 2, 3]`;
+
+    const scopeTracker = new TestScopeTracker({ preserveExitedScopes: true });
+    parseAndWalk(code, filename, { scopeTracker });
+
+    expect(scopeTracker.isDeclaredInScope("second", "")).toBe(true);
+    expect(scopeTracker.isDeclaredInScope("rest", "")).toBe(true);
+  });
+
+  it("should track scopes when walking a non-Program subtree", () => {
+    const code = `
+    function fn(param) {
+      const local = param
+      return local
+    }
+    `;
+
+    let fn: Node | undefined;
+    parseAndWalk(code, filename, {
+      enter(node) {
+        if (node.type === "FunctionDeclaration") {
+          fn = node;
+        }
+      },
+    });
+    assert(fn);
+
+    const scopeTracker = new TestScopeTracker({ preserveExitedScopes: true });
+    walk(fn, { scopeTracker });
+
+    const declaredNames = [...scopeTracker.getScopes().values()].flatMap((declarations) => [
+      ...declarations.keys(),
+    ]);
+    expect(declaredNames).toContain("param");
+    expect(declaredNames).toContain("local");
+  });
+});
+
 export class TestScopeTracker extends ScopeTracker {
   getScopes() {
     return this.scopes;

--- a/test/scope-tracker.test.ts
+++ b/test/scope-tracker.test.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from "node:fs";
 import type { Node } from "oxc-parser";
 import { assert, describe, expect, it } from "vite-plus/test";
 import type { IsReferenceIdentifierOptions, ScopeTrackerQueryOptions } from "../src";
@@ -1825,6 +1826,50 @@ describe("optimized scope tracking without callbacks", () => {
     ]);
     expect(declaredNames).toContain("param");
     expect(declaredNames).toContain("local");
+  });
+
+  it("should keep the scope enter fast path in sync with the node types it guards", () => {
+    const source = readFileSync(new URL("../src/scope-tracker.ts", import.meta.url), "utf8");
+    const { program } = parseAndWalk(source, "scope-tracker.ts", {});
+
+    const guardedTypes = new Set<string>();
+    const handledTypes = new Set<string>();
+
+    walk(program, {
+      enter(node) {
+        if (
+          node.type === "VariableDeclarator" &&
+          node.id.type === "Identifier" &&
+          node.id.name === "SCOPE_ENTER_TYPES"
+        ) {
+          assert(node.init?.type === "NewExpression");
+          const [elements] = node.init.arguments;
+          assert(elements?.type === "ArrayExpression");
+          for (const element of elements.elements) {
+            assert(element?.type === "Literal" && typeof element.value === "string");
+            guardedTypes.add(element.value);
+          }
+        }
+
+        if (
+          node.type === "PropertyDefinition" &&
+          node.key.type === "Identifier" &&
+          node.key.name === "processNodeEnter"
+        ) {
+          walk(node, {
+            enter(inner) {
+              if (inner.type === "SwitchCase" && inner.test?.type === "Literal") {
+                assert(typeof inner.test.value === "string");
+                handledTypes.add(inner.test.value);
+              }
+            },
+          });
+        }
+      },
+    });
+
+    expect(handledTypes.size).toBeGreaterThan(20);
+    expect([...guardedTypes].sort()).toEqual([...handledTypes].sort());
   });
 });
 

--- a/test/walker.bench.ts
+++ b/test/walker.bench.ts
@@ -6,10 +6,17 @@ import { isReferenceIdentifier, parseAndWalk, ScopeTracker, walk } from "../src"
 
 const rootDir = fileURLToPath(new URL("..", import.meta.url));
 
-const code = readFileSync(
-  join(rootDir, "node_modules/@vue/compiler-sfc/dist/compiler-sfc.esm-browser.js"),
-  "utf8",
-);
+const fixture = join(rootDir, "node_modules/@vue/compiler-sfc/dist/compiler-sfc.esm-browser.js");
+
+let code: string;
+try {
+  code = readFileSync(fixture, "utf8");
+} catch (error) {
+  throw new Error(
+    `Could not read the benchmark fixture at ${fixture}. Run \`vp install\` to install \`@vue/compiler-sfc\`, or update the path if its dist filenames have changed.`,
+    { cause: error },
+  );
+}
 
 const { program } = parseAndWalk(code, "compiler-sfc.js", {});
 

--- a/test/walker.bench.ts
+++ b/test/walker.bench.ts
@@ -1,0 +1,60 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { bench, describe } from "vite-plus/test";
+import { isReferenceIdentifier, parseAndWalk, ScopeTracker, walk } from "../src";
+
+const rootDir = fileURLToPath(new URL("..", import.meta.url));
+
+const code = readFileSync(
+  join(rootDir, "node_modules/@vue/compiler-sfc/dist/compiler-sfc.esm-browser.js"),
+  "utf8",
+);
+
+const { program } = parseAndWalk(code, "compiler-sfc.js", {});
+
+let sink = 0;
+
+describe("walker on @vue/compiler-sfc", () => {
+  bench("walk", () => {
+    walk(program, {
+      enter(node) {
+        if (node.type === "Identifier") {
+          sink++;
+        }
+      },
+    });
+  });
+
+  bench("walk with scope tracking", () => {
+    walk(program, { scopeTracker: new ScopeTracker() });
+    sink++;
+  });
+
+  bench("detect unmatched identifiers", () => {
+    const scopeTracker = new ScopeTracker({ preserveExitedScopes: true });
+
+    // first pass to collect all declarations and hoist them
+    walk(program, { scopeTracker });
+    scopeTracker.freeze();
+
+    const unmatched = new Set<string>();
+    walk(program, {
+      scopeTracker,
+      enter(node, parent) {
+        // re-export specifiers refer to the other module's exports
+        if (node.type === "ExportNamedDeclaration" && node.source) {
+          this.skip();
+          return;
+        }
+        if (node.type !== "Identifier" && node.type !== "JSXIdentifier") {
+          return;
+        }
+        if (isReferenceIdentifier(node, parent) && !scopeTracker.isDeclared(node.name)) {
+          unmatched.add(node.name);
+        }
+      },
+    });
+    sink += unmatched.size;
+  });
+});


### PR DESCRIPTION
this PR significantly improves the performance of the walker and the `ScopeTracker`

the most notable improvements for the walker:
- every node used to be validated by `isNode` twice: once when discovered as a child, and again when entering `_walk`; the second check is gone now (`~26%` improvement)
- dropped redundant `v.type != null` check in `isNode` (`~17%` improvement)
- when enumerating children, the scalar value `type` / `start` / `end` keys (which are present on every node), are now skipped (`~8%` improvement)
- when doing a `ScopeTracker` pre-pass without `enter` + `leave` callbacks, the walker now uses a more optimized path without the boilerplate for `this.skip()`, `this.replace()`, etc. (`~10%` improvement for the pre-pass)

the most notable improvements for the `ScopeTracker`:
- by getting rid of some switch statements (which result in long chains of string comparisons), the `ScopeTracker` now avoids multiple comparisons for every node enter / leave.
entering bails out early through a Set lookup for most nodes, and thanks to `pushScope` remembering which node created each scope on a stack, leaving a scope is just a pointer comparison -> the bonus is also that there is no leave-type list any more, so the enter / leave lists can never drift apart (`~17%` improvement)
- previously, every `pushScope` / `popScope` rebuilt the current scope key from scratch with `scopeIndexStack.slice(0, -1).join("-")` (array allocation + join for every scope in the AST); now the key is constructed incrementally and previous keys are remembered on a stack (`~38%` improvement for relevant use cases)


-----
I added `@vue/compiler-sfc` as a dev dependency, pinned to a specific version, to have a large reference file for the bench test. I'm open to suggestions for better solutions for this, but I wanted to avoid committing such file to the repository.

I ran the old implementation (from `main`) on the file and then compared it to the one from this PR, with the following results on my `M2 Max`:

<img width="812" height="123" alt="image" src="https://github.com/user-attachments/assets/c2fef837-95e3-4017-8532-1a096725ceb6" />

As you can see, the base walker improved `1.5x`, and when combined with the `ScopeTracker` for detecting unmatched identifiers (unimport's use case), it is almost `2x` faster compared to the previous implementation! 🚀