### PR TITLE
fix: improve scope tracking accuracy

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ export {
   isReferenceIdentifier,
   ScopeTrackerFunctionParam,
   ScopeTrackerFunction,
+  ScopeTrackerFunctionArguments,
   ScopeTrackerVariable,
   ScopeTrackerIdentifier,
   ScopeTrackerImport,

--- a/src/scope-tracker.ts
+++ b/src/scope-tracker.ts
@@ -18,6 +18,7 @@ import type { Identifier } from "./walk";
 import { walk } from "./walk";
 
 export interface ScopeTrackerProtected {
+  onWalkStart: (root: Node) => void;
   processNodeEnter: (node: Node) => void;
   processNodeLeave: (node: Node) => void;
 }
@@ -130,6 +131,14 @@ export class ScopeTracker {
   constructor(options: ScopeTrackerOptions = {}) {
     this.options = options;
   }
+
+  protected onWalkStart: ScopeTrackerProtected["onWalkStart"] = (root) => {
+    if (this.scopeIndexStack.length === 0 && root.type !== "Program") {
+      // when the walk does not start at a Program, initialize the root frame
+      // so that the first pushed scope gets its own key instead of the root ""
+      this.scopeIndexStack.push(0);
+    }
+  };
 
   protected pushScope(owner: Node) {
     const depthIndex = this.scopeIndexStack[this.scopeIndexStack.length - 1];

--- a/src/scope-tracker.ts
+++ b/src/scope-tracker.ts
@@ -313,12 +313,16 @@ export class ScopeTracker {
         break;
 
       case "ImportDeclaration":
-        // imports are referencable both as values and as types
+        // imports are referencable both as values and as types,
+        // except type-only imports
         for (const specifier of node.specifiers) {
+          const isTypeOnly =
+            node.importKind === "type" ||
+            (specifier.type === "ImportSpecifier" && specifier.importKind === "type");
           this.declareIdentifier(
             specifier.local.name,
             new ScopeTrackerImport(specifier, this.scopeIndexKey, node),
-            { value: true, type: true },
+            { value: !isTypeOnly, type: true },
           );
         }
         break;

--- a/src/scope-tracker.ts
+++ b/src/scope-tracker.ts
@@ -892,7 +892,9 @@ export function getUndeclaredIdentifiersInFunction(node: Function | ArrowFunctio
  * @returns true if scope A is a child of scope B, false otherwise (also when they are the same)
  */
 function isChildScope(a: string, b: string) {
-  return a.startsWith(b) && a.length > b.length;
+  // the segment boundary check prevents sibling scopes sharing a string prefix
+  // (e.g. `10` and `1`) from being treated as nested
+  return a.length > b.length && a.startsWith(b) && (b === "" || a[b.length] === "-");
 }
 
 abstract class BaseNode<T extends Node = Node> {

--- a/src/scope-tracker.ts
+++ b/src/scope-tracker.ts
@@ -49,6 +49,11 @@ const SCOPE_ENTER_TYPES = new Set<Node["type"]>([
   "TSTypeParameter",
   "TSMappedType",
   "TSEnumBody",
+  "TSMethodSignature",
+  "TSCallSignatureDeclaration",
+  "TSConstructSignatureDeclaration",
+  "TSFunctionType",
+  "TSConstructorType",
   "CatchClause",
   "ForStatement",
   "ForOfStatement",
@@ -244,6 +249,13 @@ export class ScopeTracker {
       case "StaticBlock":
       case "SwitchStatement":
       case "TSModuleBlock":
+      // signatures and function types get a scope so that their type parameters
+      // do not leak to sibling members (`interface I { m<T>(x: T): T; prop: T }`)
+      case "TSMethodSignature":
+      case "TSCallSignatureDeclaration":
+      case "TSConstructSignatureDeclaration":
+      case "TSFunctionType":
+      case "TSConstructorType":
         this.pushScope(node);
         break;
 

--- a/src/scope-tracker.ts
+++ b/src/scope-tracker.ts
@@ -54,6 +54,7 @@ const SCOPE_ENTER_TYPES = new Set<Node["type"]>([
   "TSConstructSignatureDeclaration",
   "TSFunctionType",
   "TSConstructorType",
+  "TSConditionalType",
   "CatchClause",
   "ForStatement",
   "ForOfStatement",
@@ -256,6 +257,8 @@ export class ScopeTracker {
       case "TSConstructSignatureDeclaration":
       case "TSFunctionType":
       case "TSConstructorType":
+      // `infer` declarations are scoped to the conditional type (`T extends (infer U)[] ? U : never`)
+      case "TSConditionalType":
         this.pushScope(node);
         break;
 

--- a/src/scope-tracker.ts
+++ b/src/scope-tracker.ts
@@ -53,6 +53,7 @@ const SCOPE_ENTER_TYPES = new Set<Node["type"]>([
   "ForStatement",
   "ForOfStatement",
   "ForInStatement",
+  "SwitchStatement",
 ]);
 
 /**
@@ -241,6 +242,7 @@ export class ScopeTracker {
       case "Program":
       case "BlockStatement":
       case "StaticBlock":
+      case "SwitchStatement":
       case "TSModuleBlock":
         this.pushScope(node);
         break;

--- a/src/scope-tracker.ts
+++ b/src/scope-tracker.ts
@@ -131,6 +131,11 @@ export class ScopeTracker {
   protected scopeIndexKey = "";
   protected scopes: Map<string, Map<string, ScopeTrackerNode>> = new Map();
   protected typeScopes: Map<string, Map<string, ScopeTrackerNode>> = new Map();
+  /**
+   * The implicit `arguments` keyed by the function that introduces them,
+   * so that repeated queries return the same instance.
+   */
+  protected implicitArguments = new WeakMap<Function, ScopeTrackerFunctionArguments>();
 
   protected options: Partial<ScopeTrackerOptions>;
   protected isFrozen = false;
@@ -532,10 +537,32 @@ export class ScopeTracker {
    */
   getDeclaration(name: string, options?: ScopeTrackerQueryOptions): ScopeTrackerNode | null {
     const mode = options?.mode ?? "value";
-    return (
+    const declaration =
       (mode !== "type" ? this.getDeclarationIn(this.scopes, name) : null) ??
-      (mode !== "value" ? this.getDeclarationIn(this.typeScopes, name) : null)
-    );
+      (mode !== "value" ? this.getDeclarationIn(this.typeScopes, name) : null);
+
+    // the implicit `arguments` declaration of the closest regular function applies
+    // unless an explicit declaration shadows it
+    if (name === "arguments" && mode !== "type") {
+      const owners = this.scopeOwnerStack;
+      for (let i = owners.length - 1; i >= 0; i--) {
+        const owner = owners[i]!;
+        if (owner.type === "FunctionDeclaration" || owner.type === "FunctionExpression") {
+          const fnScope = this.getScopeKeyAt(i);
+          if (!declaration || isChildScope(fnScope, declaration.scope)) {
+            let implicit = this.implicitArguments.get(owner);
+            if (!implicit) {
+              implicit = new ScopeTrackerFunctionArguments(owner, fnScope);
+              this.implicitArguments.set(owner, implicit);
+            }
+            return implicit;
+          }
+          break;
+        }
+      }
+    }
+
+    return declaration;
   }
 
   /**
@@ -1044,6 +1071,18 @@ export class ScopeTrackerFunction extends BaseNode<Function | ArrowFunctionExpre
   }
 }
 
+export class ScopeTrackerFunctionArguments extends BaseNode<Function> {
+  type = "FunctionArguments" as const;
+
+  get start() {
+    return this.node.start;
+  }
+
+  get end() {
+    return this.node.end;
+  }
+}
+
 export class ScopeTrackerVariable extends BaseNode<Identifier> {
   type = "Variable" as const;
   variableNode: VariableDeclaration;
@@ -1101,6 +1140,7 @@ export class ScopeTrackerCatchParam extends BaseNode {
 export type ScopeTrackerNode =
   | ScopeTrackerFunctionParam
   | ScopeTrackerFunction
+  | ScopeTrackerFunctionArguments
   | ScopeTrackerVariable
   | ScopeTrackerIdentifier
   | ScopeTrackerImport

--- a/src/scope-tracker.ts
+++ b/src/scope-tracker.ts
@@ -174,17 +174,49 @@ export class ScopeTracker {
     this.scopeIndexKey = this.scopeKeyStack.pop() ?? "";
   }
 
+  /**
+   * Get the key of the active scope at the given index of the scope stacks.
+   */
+  protected getScopeKeyAt(index: number) {
+    // `scopeKeyStack[i]` holds the key of the parent of the scope at `i`,
+    // so the key of the scope at `index` is the next entry, or the current key at the top
+    return index === this.scopeKeyStack.length - 1
+      ? this.scopeIndexKey
+      : this.scopeKeyStack[index + 1]!;
+  }
+
+  /**
+   * Get the key of the closest function-like scope (function bodies, static blocks,
+   * module blocks and the root scope), which is where `var` declarations are hoisted to.
+   */
+  protected getVarScopeKey(): string {
+    const owners = this.scopeOwnerStack;
+    for (let i = owners.length - 1; i >= 0; i--) {
+      switch (owners[i]!.type) {
+        case "FunctionDeclaration":
+        case "FunctionExpression":
+        case "ArrowFunctionExpression":
+        case "TSDeclareFunction":
+        case "Program":
+        case "StaticBlock":
+        case "TSModuleBlock":
+          return this.getScopeKeyAt(i);
+      }
+    }
+    return "";
+  }
+
   protected declareInNamespace(
     scopes: Map<string, Map<string, ScopeTrackerNode>>,
     name: string,
-    data: ScopeTrackerNode,
+    node: ScopeTrackerNode,
   ) {
-    let scope = scopes.get(this.scopeIndexKey);
+    let scope = scopes.get(node.scope);
     if (!scope) {
       scope = new Map();
-      scopes.set(this.scopeIndexKey, scope);
+      scopes.set(node.scope, scope);
     }
-    scope.set(name, data);
+    scope.set(name, node);
   }
 
   protected declareIdentifier(
@@ -226,15 +258,21 @@ export class ScopeTracker {
       return;
     }
 
+    // `var` declarations are hoisted to the enclosing function-like scope
+    const scopeKey =
+      parent.type === "VariableDeclaration" && parent.kind === "var"
+        ? this.getVarScopeKey()
+        : this.scopeIndexKey;
+
     const identifiers = getPatternIdentifiers(pattern);
     for (const identifier of identifiers) {
       this.declareIdentifier(
         identifier.name,
         parent.type === "VariableDeclaration"
-          ? new ScopeTrackerVariable(identifier, this.scopeIndexKey, parent)
+          ? new ScopeTrackerVariable(identifier, scopeKey, parent)
           : parent.type === "CatchClause"
-            ? new ScopeTrackerCatchParam(identifier, this.scopeIndexKey, parent)
-            : new ScopeTrackerFunctionParam(identifier, this.scopeIndexKey, parent),
+            ? new ScopeTrackerCatchParam(identifier, scopeKey, parent)
+            : new ScopeTrackerFunctionParam(identifier, scopeKey, parent),
       );
     }
   }

--- a/src/walker/sync.ts
+++ b/src/walker/sync.ts
@@ -163,6 +163,9 @@ export class WalkerSync extends WalkerBase {
     if (!isNode(input)) {
       return null;
     }
+    if (scopeTracker) {
+      scopeTracker.onWalkStart(input);
+    }
 
     // perf: without enter/leave handlers no node can be skipped, removed or replaced,
     // so a minimal recursion without the callback bookkeeping is enough

--- a/src/walker/sync.ts
+++ b/src/walker/sync.ts
@@ -59,6 +59,7 @@ export class WalkerSync extends WalkerBase {
       }
       let currentNode: Node | null = input;
       let removedInEnter = false;
+      let replacedInEnter = false;
       let skipChildren = skip;
 
       if (enter && !skip) {
@@ -76,6 +77,7 @@ export class WalkerSync extends WalkerBase {
 
         if (this._replacement && !this._remove) {
           currentNode = this._replacement;
+          replacedInEnter = true;
           this.replace(parent, key, index, this._replacement);
           // the walker continues into the replacement's children,
           // so track the declarations and scopes it introduces
@@ -132,8 +134,8 @@ export class WalkerSync extends WalkerBase {
       if (scopeTracker) {
         // when the node was replaced in the enter phase, the scopes of the replacement
         // were pushed on top of the original's, so pop them first
-        if (currentNode && currentNode !== input) {
-          scopeTracker.processNodeLeave(currentNode);
+        if (replacedInEnter) {
+          scopeTracker.processNodeLeave(currentNode!);
         }
         scopeTracker.processNodeLeave(input);
       }

--- a/src/walker/sync.ts
+++ b/src/walker/sync.ts
@@ -77,6 +77,11 @@ export class WalkerSync extends WalkerBase {
         if (this._replacement && !this._remove) {
           currentNode = this._replacement;
           this.replace(parent, key, index, this._replacement);
+          // the walker continues into the replacement's children,
+          // so track the declarations and scopes it introduces
+          if (scopeTracker) {
+            scopeTracker.processNodeEnter(currentNode);
+          }
         }
 
         if (this._remove) {
@@ -125,6 +130,11 @@ export class WalkerSync extends WalkerBase {
       }
 
       if (scopeTracker) {
+        // when the node was replaced in the enter phase, the scopes of the replacement
+        // were pushed on top of the original's, so pop them first
+        if (currentNode && currentNode !== input) {
+          scopeTracker.processNodeLeave(currentNode);
+        }
         scopeTracker.processNodeLeave(input);
       }
 

--- a/test/scope-tracker.test.ts
+++ b/test/scope-tracker.test.ts
@@ -1346,6 +1346,22 @@ describe("reference identifiers", () => {
     expect(getUnmatchedIdentifiers(code)).toEqual(["e1", "p1", "p2"]);
   });
 
+  it("should scope declarations in switch cases to the switch body", () => {
+    const code = `
+    const input = 1
+    switch (input) {
+      case 1:
+        let leaked = 1
+        break
+      default:
+        leaked = 2
+    }
+    const after = leaked
+    `;
+
+    expect(getUnmatchedIdentifiers(code)).toEqual(["leaked"]);
+  });
+
   it("should resolve references to imports", () => {
     const code = `
     import { Bar } from 'foobar'

--- a/test/scope-tracker.test.ts
+++ b/test/scope-tracker.test.ts
@@ -943,6 +943,37 @@ class Klass {}
     expect(klass.start).toBe(code.indexOf("Klass"));
     expect(klass.end).toBe(code.indexOf("Klass") + "Klass".length);
   });
+
+  it("should track declarations introduced by replacement nodes", () => {
+    const { program } = parseAndWalk("let replaced = 1", filename, {});
+    const replacement = program.body[0];
+    assert(replacement);
+
+    const code = `
+    let original = 1
+    original
+    `;
+
+    const scopeTracker = new ScopeTracker();
+    let referenceCount = 0;
+
+    parseAndWalk(code, filename, {
+      scopeTracker,
+      enter(node) {
+        if (node.type === "VariableDeclaration") {
+          this.replace(replacement);
+        }
+        if (node.type === "Identifier" && node.name === "original") {
+          referenceCount++;
+          expect(scopeTracker.isDeclared("replaced")).toBe(true);
+        }
+      },
+    });
+
+    // the walker walks the replacement's children instead of the original declaration,
+    // so the only `original` identifier left is the standalone reference
+    expect(referenceCount).toBe(1);
+  });
 });
 
 describe("parsing", () => {

--- a/test/scope-tracker.test.ts
+++ b/test/scope-tracker.test.ts
@@ -1,7 +1,11 @@
 import { readFileSync } from "node:fs";
 import type { Node } from "oxc-parser";
 import { assert, describe, expect, it } from "vite-plus/test";
-import type { IsReferenceIdentifierOptions, ScopeTrackerQueryOptions } from "../src";
+import type {
+  IsReferenceIdentifierOptions,
+  ScopeTrackerNode,
+  ScopeTrackerQueryOptions,
+} from "../src";
 import {
   getUndeclaredIdentifiersInFunction,
   isBindingIdentifier,
@@ -1111,6 +1115,79 @@ describe("parsing", () => {
     });
 
     expect(processedFunctions).toBe(5);
+  });
+
+  it("should treat the implicitly bound arguments as declared in a function", () => {
+    let fn: Node | undefined;
+    parseAndWalk(`const f = function () { return arguments.length }`, filename, {
+      enter(node) {
+        if (node.type === "FunctionExpression") {
+          fn = node;
+        }
+      },
+    });
+    assert(fn?.type === "FunctionExpression");
+
+    // `arguments` is implicitly declared in regular functions
+    expect(getUndeclaredIdentifiersInFunction(fn)).toEqual([]);
+
+    let arrow: Node | undefined;
+    parseAndWalk(`const arrow = () => arguments.length`, filename, {
+      enter(node) {
+        if (node.type === "ArrowFunctionExpression") {
+          arrow = node;
+        }
+      },
+    });
+    assert(arrow?.type === "ArrowFunctionExpression");
+
+    // arrow functions don't declare `arguments`
+    expect(getUndeclaredIdentifiersInFunction(arrow)).toEqual(["arguments"]);
+
+    // an explicit declaration shadows the implicit `arguments`
+    const scopeTracker = new ScopeTracker();
+    let beforeDeclaration: ScopeTrackerNode | null | undefined;
+    let shadowed: ScopeTrackerNode | null | undefined;
+    parseAndWalk(
+      `const f = function () {
+        const before = 1
+        let arguments = 42
+        return arguments
+      }`,
+      filename,
+      {
+        scopeTracker,
+        enter(node) {
+          if (node.type === "Identifier" && node.name === "before") {
+            beforeDeclaration = scopeTracker.getDeclaration("arguments");
+            expect(scopeTracker.getDeclaration("arguments")).toBe(beforeDeclaration);
+          } else if (node.type === "ReturnStatement") {
+            shadowed = scopeTracker.getDeclaration("arguments");
+          }
+        },
+      },
+    );
+
+    // the function itself defines `arguments`, so it is already declared before the explicit declaration
+    assert(beforeDeclaration);
+    expect(beforeDeclaration.type).toBe("FunctionArguments");
+
+    // after the explicit declaration, it resolves to the explicit binding
+    assert(shadowed instanceof ScopeTrackerVariable);
+    expect(shadowed.node.name).toBe("arguments");
+
+    // a parameter named `arguments` shadows the implicit binding as well
+    const paramScopeTracker = new ScopeTracker();
+    let param: ScopeTrackerNode | null | undefined;
+    parseAndWalk(`const f = function (arguments) { return arguments }`, filename, {
+      scopeTracker: paramScopeTracker,
+      enter(node) {
+        if (node.type === "ReturnStatement") {
+          param = paramScopeTracker.getDeclaration("arguments");
+        }
+      },
+    });
+    assert(param instanceof ScopeTrackerFunctionParam);
   });
 
   it("should correctly compare identifiers defined in different scopes", () => {

--- a/test/scope-tracker.test.ts
+++ b/test/scope-tracker.test.ts
@@ -820,6 +820,44 @@ describe("scope tracker", () => {
     ]);
   });
 
+  it("should not treat sibling scopes with a shared digit prefix as nested", () => {
+    // 11 sibling blocks produce the scope keys '0' through '10'
+    // scope '10' shares the string prefix '1' with scope '1' but is its sibling, not its child
+    const blocks = Array.from({ length: 10 }, (_, i) => `{ const x${i} = ${i} }`).join("\n");
+    const code = `
+    ${blocks}
+    {
+      const x10 = 10
+      {
+        const y = 11
+      }
+    }
+    `;
+
+    const scopeTracker = new ScopeTracker();
+    let checked = false;
+
+    parseAndWalk(code, filename, {
+      scopeTracker,
+      enter(node) {
+        if (node.type === "Identifier" && node.name === "y") {
+          checked = true;
+          expect(scopeTracker.getCurrentScope()).toBe("10-0");
+          expect(scopeTracker.isCurrentScopeUnder("")).toBe(true);
+          expect(scopeTracker.isCurrentScopeUnder("10")).toBe(true);
+          expect(scopeTracker.isCurrentScopeUnder("1")).toBe(false);
+
+          const declaration = scopeTracker.getDeclaration("x10");
+          assert(declaration);
+          expect(declaration.isUnderScope("")).toBe(true);
+          expect(declaration.isUnderScope("1")).toBe(false);
+        }
+      },
+    });
+
+    expect(checked).toBe(true);
+  });
+
   it("should provide the position of the whole relevant node for declarations", () => {
     const code = `import { imp } from 'mod'
 const a = 1

--- a/test/scope-tracker.test.ts
+++ b/test/scope-tracker.test.ts
@@ -1517,6 +1517,67 @@ describe("reference identifiers", () => {
     expect(getUnmatchedIdentifiers(code)).toEqual([]);
   });
 
+  it("should hoist var declarations to the enclosing function scope", () => {
+    const code = `
+    function fn(cond) {
+      if (cond) {
+        var fromBlock = 1
+      }
+      try {
+        var fromTry = 1
+      } catch (e) {
+        var fromCatch = 1
+      }
+      for (var i = 0; i < 1; i++) {}
+      for (var key in {}) {}
+      for (var item of []) {}
+      switch (cond) {
+        case 1:
+          var fromCase = 1
+      }
+      {
+        {
+          var fromNested = 1
+        }
+      }
+      return [fromBlock, fromTry, fromCatch, i, key, item, fromCase, fromNested]
+    }
+    {
+      var topLevel = 1
+    }
+    topLevel
+    `;
+
+    expect(getUnmatchedIdentifiers(code)).toEqual([]);
+  });
+
+  it("should not hoist var declarations past function boundaries", () => {
+    const code = `
+    function outer() {
+      var inFn = 1
+      const arrow = () => { var inArrow = 1 }
+      function inner() { var inInner = 1 }
+    }
+    class C {
+      static {
+        var inStatic = 1
+      }
+    }
+    namespace N {
+      var inNamespace = 1
+    }
+    inFn; inArrow; inInner; inStatic; inNamespace
+    `;
+
+    expect(getUnmatchedIdentifiers(code)).toEqual([
+      "inArrow",
+      "inFn",
+      "inInner",
+      "inNamespace",
+      "inStatic",
+    ]);
+  });
+
   it("should detect references in JSX", () => {
     const code = `
     const el = <Foo prop={bar}>{baz}</Foo>

--- a/test/scope-tracker.test.ts
+++ b/test/scope-tracker.test.ts
@@ -1793,6 +1793,14 @@ describe("reference identifiers", () => {
     ]);
   });
 
+  it("should scope infer declarations to the conditional type", () => {
+    const code = `
+    type ElementType<T> = [T extends (infer U)[] ? U : never, U]
+    `;
+
+    expect(getUnmatchedIdentifiers(code, filename, { mode: "type" })).toEqual(["U"]);
+  });
+
   it("should detect references in JSX member expressions", () => {
     expect(getUnmatchedIdentifiers(`const el = <Foo.Bar.baz />`, "test.tsx")).toEqual(["Foo"]);
     expect(getUnmatchedIdentifiers(`const el = <foo.bar />`, "test.tsx")).toEqual(["foo"]);

--- a/test/scope-tracker.test.ts
+++ b/test/scope-tracker.test.ts
@@ -1655,6 +1655,23 @@ describe("reference identifiers", () => {
     ]);
   });
 
+  it("should report runtime globals and language constants as unresolved references", () => {
+    const code = `
+    const a = undefined ?? NaN ?? Infinity
+    const b = Array.from(console)
+    globalThis.foo
+    `;
+
+    expect(getUnmatchedIdentifiers(code)).toEqual([
+      "Array",
+      "Infinity",
+      "NaN",
+      "console",
+      "globalThis",
+      "undefined",
+    ]);
+  });
+
   it("should detect references in JSX", () => {
     const code = `
     const el = <Foo prop={bar}>{baz}</Foo>

--- a/test/scope-tracker.test.ts
+++ b/test/scope-tracker.test.ts
@@ -519,6 +519,37 @@ describe("scope tracker", () => {
     expect(scopeTracker.getScopes().get("")?.size).toBe(3);
   });
 
+  it("should declare type-only imports in the type namespace only", () => {
+    const code = `
+    import type Foo from 'module-a'
+    import type { Bar } from 'module-b'
+    import type * as Ns from 'module-c'
+    import { type Inline, value } from 'module-d'
+    const marker = 1
+    `;
+
+    const scopeTracker = new ScopeTracker();
+    let checked = false;
+
+    parseAndWalk(code, filename, {
+      scopeTracker,
+      enter(node) {
+        if (node.type === "Identifier" && node.name === "marker") {
+          checked = true;
+          for (const name of ["Foo", "Bar", "Ns", "Inline"]) {
+            expect(scopeTracker.isDeclared(name, { mode: "type" })).toBe(true);
+            expect(scopeTracker.isDeclared(name, { mode: "value" })).toBe(false);
+          }
+
+          expect(scopeTracker.isDeclared("value", { mode: "value" })).toBe(true);
+          expect(scopeTracker.isDeclared("value", { mode: "type" })).toBe(true);
+        }
+      },
+    });
+
+    expect(checked).toBe(true);
+  });
+
   it("should resolve identifiers used as switch case labels", () => {
     const code = `
     import { foo } from './foo'

--- a/test/scope-tracker.test.ts
+++ b/test/scope-tracker.test.ts
@@ -1766,6 +1766,33 @@ describe("reference identifiers", () => {
     });
   });
 
+  it("should not leak type parameters of signatures to sibling members", () => {
+    const code = `
+    interface Props {
+      transform<U>(value: U): U
+      fallback: U
+    }
+    type Obj = {
+      method<M>(value: M): M
+      prop: M
+    }
+    type FnPair = [<F>(value: F) => F, F]
+    type CtorPair = [new <C>(value: C) => C, C]
+    interface WithCall {
+      <S>(value: S): S
+      also: S
+    }
+    `;
+
+    expect(getUnmatchedIdentifiers(code, filename, { mode: "type" })).toEqual([
+      "C",
+      "F",
+      "M",
+      "S",
+      "U",
+    ]);
+  });
+
   it("should detect references in JSX member expressions", () => {
     expect(getUnmatchedIdentifiers(`const el = <Foo.Bar.baz />`, "test.tsx")).toEqual(["Foo"]);
     expect(getUnmatchedIdentifiers(`const el = <foo.bar />`, "test.tsx")).toEqual(["foo"]);

--- a/test/scope-tracker.test.ts
+++ b/test/scope-tracker.test.ts
@@ -70,6 +70,49 @@ describe("scope tracker", () => {
     expect(scopeTracker.getScopes().size).toBe(2);
   });
 
+  it("should create separate scopes when walking a non-Program root", () => {
+    let fnDecl: Node | undefined;
+    let fnExpr: Node | undefined;
+    parseAndWalk(
+      `
+      function foo(p) { const x = 1 }
+      const f = function bar(q) { const y = 1 }
+      `,
+      filename,
+      {
+        enter(node) {
+          if (node.type === "FunctionDeclaration") {
+            fnDecl = node;
+          } else if (node.type === "FunctionExpression") {
+            fnExpr = node;
+          }
+        },
+      },
+    );
+    assert(fnDecl && fnExpr);
+
+    // when walking a function directly, its name is declared in the root scope,
+    // while the parameters and body get their own child scopes
+    const declTracker = new TestScopeTracker({ preserveExitedScopes: true });
+    walk(fnDecl, { scopeTracker: declTracker });
+
+    const declScopes = declTracker.getScopes();
+    expect([...(declScopes.get("")?.keys() ?? [])]).toEqual(["foo"]);
+    expect([...(declScopes.get("0")?.keys() ?? [])]).toEqual(["p"]);
+    expect([...(declScopes.get("0-0")?.keys() ?? [])]).toEqual(["x"]);
+
+    // a function expression pushes a scope for its name as well,
+    // and nothing is declared in the root scope
+    const exprTracker = new TestScopeTracker({ preserveExitedScopes: true });
+    walk(fnExpr, { scopeTracker: exprTracker });
+
+    const exprScopes = exprTracker.getScopes();
+    expect(exprScopes.get("")).toBeUndefined();
+    expect([...(exprScopes.get("0")?.keys() ?? [])]).toEqual(["bar"]);
+    expect([...(exprScopes.get("0-0")?.keys() ?? [])]).toEqual(["q"]);
+    expect([...(exprScopes.get("0-0-0")?.keys() ?? [])]).toEqual(["y"]);
+  });
+
   it("should generate scope key correctly and not allocate unnecessary scopes", () => {
     const code = `
     // starting in global scope ("")


### PR DESCRIPTION
this fixes more edge cases I discovered - mostly related to the [newly-added](https://github.com/oxc-project/oxc-walker/pull/344) support of type references, so not relevant to previously released versions of this package

however, there are some fixes for pre-existing bugs